### PR TITLE
Add Spring Boot OCR service for UAE plate extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,81 @@
-# UAE-Car-Pallet-Reader
+# UAE Car Plate Reader
+
+A Spring Boot 3 (Java 17) REST API for extracting and normalizing UAE car plate numbers from uploaded images.
+
+## Features
+
+- Accepts multiple images in a single multipart/form-data request.
+- Uses [Tess4J](https://tess4j.sourceforge.net/) as a Java wrapper around the Tesseract OCR engine.
+- Applies lightweight grayscale and contrast preprocessing before running OCR.
+- Normalizes the OCR output by removing noise, duplicates, and Dubai-specific prefixes.
+- Provides per-image extraction results including the raw OCR text and the cleaned plate number.
+
+## Getting Started
+
+### Prerequisites
+
+- Java 17+
+- Maven 3.8+
+- [Tesseract OCR](https://github.com/tesseract-ocr/tesseract) runtime with the `eng` (English) language data installed. On macOS or Linux you can typically install this via your package manager. Make note of the tessdata directory path.
+
+### Configuration
+
+By default the application expects the Tesseract runtime to be discoverable on the system path. If you installed the trained data files in a non-default location, expose it via the `TESSDATA_PREFIX` environment variable or provide `tesseract.datapath` as a Spring property:
+
+```shell
+java -Dtesseract.datapath=/usr/share/tesseract-ocr/5/tessdata -jar target/uae-car-pallet-reader-0.0.1-SNAPSHOT.jar
+```
+
+### Build and Run
+
+```shell
+mvn clean package
+java -jar target/uae-car-pallet-reader-0.0.1-SNAPSHOT.jar
+```
+
+The API will be available at `http://localhost:8080`.
+
+### API Usage
+
+`POST /api/v1/plates/extract`
+
+- **Consumes**: `multipart/form-data`
+- **Request Part**: `images` (one or more image files)
+
+Example using `curl`:
+
+```shell
+curl -X POST http://localhost:8080/api/v1/plates/extract \ 
+  -F "images=@/path/to/maxima.jpg" \ 
+  -F "images=@/path/to/lexus.jpg"
+```
+
+Sample response:
+
+```json
+{
+  "results": [
+    {
+      "fileName": "maxima.jpg",
+      "rawText": "F\n97344",
+      "normalizedPlate": "F 97344"
+    },
+    {
+      "fileName": "lexus.jpg",
+      "rawText": "Dubai\nBB 19849",
+      "normalizedPlate": "BB 19849"
+    }
+  ]
+}
+```
+
+### Testing
+
+```shell
+mvn test
+```
+
+## Notes
+
+- OCR accuracy heavily depends on the quality of the input images. The provided preprocessing is intentionally lightweight to keep latency low; feel free to enhance it (denoising, edge detection, etc.) for production scenarios.
+- Tess4J packages native binaries for common platforms. Ensure that your deployment environment includes the required native libraries (Linux x86_64 is supported out of the box).

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,71 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>uae-car-pallet-reader</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>UAE Car Pallet Reader</name>
+    <description>Spring Boot service for extracting UAE car plate numbers from images.</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <spring.boot.version>3.1.5</spring.boot.version>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.tess4j</groupId>
+            <artifactId>tess4j</artifactId>
+            <version>5.10.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/uaecarpalletreader/UaeCarPalletReaderApplication.java
+++ b/src/main/java/com/example/uaecarpalletreader/UaeCarPalletReaderApplication.java
@@ -1,0 +1,12 @@
+package com.example.uaecarpalletreader;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class UaeCarPalletReaderApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(UaeCarPalletReaderApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/uaecarpalletreader/config/TesseractConfiguration.java
+++ b/src/main/java/com/example/uaecarpalletreader/config/TesseractConfiguration.java
@@ -1,0 +1,36 @@
+package com.example.uaecarpalletreader.config;
+
+import net.sourceforge.tess4j.Tesseract;
+import net.sourceforge.tess4j.TesseractException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TesseractConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(TesseractConfiguration.class);
+
+    @Value("${tesseract.datapath:}")
+    private String dataPath;
+
+    @Value("${tesseract.language:eng}")
+    private String language;
+
+    @Bean
+    public Tesseract tesseract() throws TesseractException {
+        Tesseract tesseract = new Tesseract();
+        if (dataPath != null && !dataPath.isBlank()) {
+            log.info("Configuring Tesseract data path: {}", dataPath);
+            tesseract.setDatapath(dataPath);
+        } else {
+            log.warn("No explicit tesseract.datapath configured. Using default search paths.");
+        }
+        tesseract.setLanguage(language);
+        tesseract.setOcrEngineMode(1); // LSTM only
+        tesseract.setPageSegMode(6); // Assume a block of text
+        return tesseract;
+    }
+}

--- a/src/main/java/com/example/uaecarpalletreader/controller/PlateRecognitionController.java
+++ b/src/main/java/com/example/uaecarpalletreader/controller/PlateRecognitionController.java
@@ -1,0 +1,42 @@
+package com.example.uaecarpalletreader.controller;
+
+import com.example.uaecarpalletreader.model.PlateExtractionResponse;
+import com.example.uaecarpalletreader.model.PlateExtractionResult;
+import com.example.uaecarpalletreader.service.PlateRecognitionService;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.CollectionUtils;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@RestController
+@RequestMapping("/api/v1/plates")
+@Validated
+public class PlateRecognitionController {
+
+    private final PlateRecognitionService service;
+
+    public PlateRecognitionController(PlateRecognitionService service) {
+        this.service = service;
+    }
+
+    @PostMapping(value = "/extract", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<PlateExtractionResponse> extract(@RequestPart("images") List<MultipartFile> images) {
+        if (CollectionUtils.isEmpty(images)) {
+            throw new ResponseStatusException(BAD_REQUEST, "At least one image must be provided");
+        }
+        List<PlateExtractionResult> results = images.stream()
+                .map(service::extractPlate)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(new PlateExtractionResponse(results));
+    }
+}

--- a/src/main/java/com/example/uaecarpalletreader/model/PlateExtractionResponse.java
+++ b/src/main/java/com/example/uaecarpalletreader/model/PlateExtractionResponse.java
@@ -1,0 +1,6 @@
+package com.example.uaecarpalletreader.model;
+
+import java.util.List;
+
+public record PlateExtractionResponse(List<PlateExtractionResult> results) {
+}

--- a/src/main/java/com/example/uaecarpalletreader/model/PlateExtractionResult.java
+++ b/src/main/java/com/example/uaecarpalletreader/model/PlateExtractionResult.java
@@ -1,0 +1,4 @@
+package com.example.uaecarpalletreader.model;
+
+public record PlateExtractionResult(String fileName, String rawText, String normalizedPlate) {
+}

--- a/src/main/java/com/example/uaecarpalletreader/service/PlateRecognitionService.java
+++ b/src/main/java/com/example/uaecarpalletreader/service/PlateRecognitionService.java
@@ -1,0 +1,72 @@
+package com.example.uaecarpalletreader.service;
+
+import com.example.uaecarpalletreader.model.PlateExtractionResult;
+import com.example.uaecarpalletreader.util.PlateNumberNormalizer;
+import jakarta.annotation.PostConstruct;
+import net.sourceforge.tess4j.Tesseract;
+import net.sourceforge.tess4j.TesseractException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.awt.image.RescaleOp;
+import java.io.IOException;
+import java.io.InputStream;
+
+@Service
+public class PlateRecognitionService {
+
+    private static final Logger log = LoggerFactory.getLogger(PlateRecognitionService.class);
+
+    private final Tesseract tesseract;
+
+    public PlateRecognitionService(Tesseract tesseract) {
+        this.tesseract = tesseract;
+    }
+
+    @PostConstruct
+    void logTesseractInfo() {
+        log.info("Tesseract OCR initialized with language: {}", tesseract.getLanguage());
+    }
+
+    public PlateExtractionResult extractPlate(MultipartFile file) {
+        String fileName = file.getOriginalFilename();
+        if (fileName == null || fileName.isBlank()) {
+            fileName = "image";
+        }
+
+        try (InputStream inputStream = file.getInputStream()) {
+            BufferedImage bufferedImage = ImageIO.read(inputStream);
+            if (bufferedImage == null) {
+                throw new IllegalArgumentException("Unsupported image type for file: " + fileName);
+            }
+
+            BufferedImage preprocessed = preprocess(bufferedImage);
+            String rawText = tesseract.doOCR(preprocessed);
+            String normalized = PlateNumberNormalizer.normalize(rawText);
+            return new PlateExtractionResult(fileName, rawText != null ? rawText.trim() : null, normalized);
+        } catch (IOException e) {
+            log.error("Failed to read image {}", fileName, e);
+            throw new IllegalStateException("Failed to read image " + fileName, e);
+        } catch (TesseractException e) {
+            log.error("Tesseract OCR failed for {}", fileName, e);
+            throw new IllegalStateException("Failed to extract text from " + fileName, e);
+        }
+    }
+
+    private BufferedImage preprocess(BufferedImage input) {
+        BufferedImage grayscale = new BufferedImage(input.getWidth(), input.getHeight(), BufferedImage.TYPE_BYTE_GRAY);
+        Graphics2D g = grayscale.createGraphics();
+        g.drawImage(input, 0, 0, null);
+        g.dispose();
+
+        RescaleOp rescaleOp = new RescaleOp(1.2f, 15, null);
+        rescaleOp.filter(grayscale, grayscale);
+
+        return grayscale;
+    }
+}

--- a/src/main/java/com/example/uaecarpalletreader/util/PlateNumberNormalizer.java
+++ b/src/main/java/com/example/uaecarpalletreader/util/PlateNumberNormalizer.java
@@ -1,0 +1,43 @@
+package com.example.uaecarpalletreader.util;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class PlateNumberNormalizer {
+
+    private static final Pattern ALPHANUMERIC_PATTERN = Pattern.compile("[A-Za-z0-9]+");
+    private static final Pattern DUBAI_PREFIX_PATTERN = Pattern.compile("(?i)(dubai\\s*)");
+
+    private PlateNumberNormalizer() {
+    }
+
+    public static String normalize(String rawText) {
+        if (rawText == null) {
+            return null;
+        }
+
+        String cleaned = rawText
+                .replaceAll("[\\n\\r]+", " ")
+                .replaceAll("[^A-Za-z0-9\\s]", " ")
+                .replaceAll("\\s+", " ")
+                .trim();
+
+        if (cleaned.isEmpty()) {
+            return null;
+        }
+
+        cleaned = DUBAI_PREFIX_PATTERN.matcher(cleaned).replaceAll("");
+
+        Matcher matcher = ALPHANUMERIC_PATTERN.matcher(cleaned);
+        StringBuilder builder = new StringBuilder();
+        while (matcher.find()) {
+            if (!builder.isEmpty()) {
+                builder.append(' ');
+            }
+            builder.append(matcher.group().toUpperCase(Locale.ROOT));
+        }
+
+        return builder.length() == 0 ? null : builder.toString();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,9 @@
+server:
+  port: 8080
+spring:
+  application:
+    name: uae-car-pallet-reader
+logging:
+  level:
+    root: INFO
+    com.example.uaecarpalletreader: DEBUG

--- a/src/test/java/com/example/uaecarpalletreader/UaeCarPalletReaderApplicationTests.java
+++ b/src/test/java/com/example/uaecarpalletreader/UaeCarPalletReaderApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.uaecarpalletreader;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class UaeCarPalletReaderApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/src/test/java/com/example/uaecarpalletreader/util/PlateNumberNormalizerTest.java
+++ b/src/test/java/com/example/uaecarpalletreader/util/PlateNumberNormalizerTest.java
@@ -1,0 +1,25 @@
+package com.example.uaecarpalletreader.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlateNumberNormalizerTest {
+
+    @Test
+    void shouldNormalizePlateWithDubaiPrefix() {
+        String normalized = PlateNumberNormalizer.normalize("Dubai bb 19849\n");
+        assertThat(normalized).isEqualTo("BB 19849");
+    }
+
+    @Test
+    void shouldNormalizeWithSpecialCharacters() {
+        String normalized = PlateNumberNormalizer.normalize("F-97344");
+        assertThat(normalized).isEqualTo("F 97344");
+    }
+
+    @Test
+    void shouldReturnNullForEmpty() {
+        assertThat(PlateNumberNormalizer.normalize("   ")).isNull();
+    }
+}


### PR DESCRIPTION
## Summary
- bootstrap a Spring Boot 3 project configured for Java 17 and Tess4J-based OCR
- add plate recognition service, response models, and REST controller to extract and normalize plate numbers from multiple images
- document build, configuration, and API usage details in the README

## Testing
- mvn test *(fails: unable to download Maven dependencies because external network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfad6e14c48332abf397d33d6e9d81