### PR TITLE
Upgrade to Java 21 and add OpenAPI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UAE Car Plate Reader
 
-A Spring Boot 3 (Java 17) REST API for extracting and normalizing UAE car plate numbers from uploaded images.
+A Spring Boot 3 (Java 21) REST API for extracting and normalizing UAE car plate numbers from uploaded images. The service now includes an OpenAPI 3 specification with an interactive Swagger UI for easy exploration.
 
 ## Features
 
@@ -14,7 +14,7 @@ A Spring Boot 3 (Java 17) REST API for extracting and normalizing UAE car plate 
 
 ### Prerequisites
 
-- Java 17+
+- Java 21+
 - Maven 3.8+
 - [Tesseract OCR](https://github.com/tesseract-ocr/tesseract) runtime with the `eng` (English) language data installed. On macOS or Linux you can typically install this via your package manager. Make note of the tessdata directory path.
 
@@ -33,7 +33,7 @@ mvn clean package
 java -jar target/uae-car-pallet-reader-0.0.1-SNAPSHOT.jar
 ```
 
-The API will be available at `http://localhost:8080`.
+The API will be available at `http://localhost:8080`. The generated Swagger UI is served at `http://localhost:8080/swagger-ui.html` and the OpenAPI JSON is available at `http://localhost:8080/v3/api-docs`.
 
 ### API Usage
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
     <description>Spring Boot service for extracting UAE car plate numbers from images.</description>
 
     <properties>
-        <java.version>17</java.version>
-        <spring.boot.version>3.1.5</spring.boot.version>
+        <java.version>21</java.version>
+        <spring.boot.version>3.3.4</spring.boot.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
     </properties>
 
@@ -37,6 +37,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.tess4j</groupId>
@@ -65,6 +70,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/example/uaecarpalletreader/UaeCarPalletReaderApplication.java
+++ b/src/main/java/com/example/uaecarpalletreader/UaeCarPalletReaderApplication.java
@@ -1,8 +1,17 @@
 package com.example.uaecarpalletreader;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+@OpenAPIDefinition(
+        info = @Info(
+                title = "UAE Car Plate Reader API",
+                version = "1.0",
+                description = "REST API for extracting and normalizing UAE vehicle plate numbers from uploaded images.",
+                contact = @Contact(name = "UAE Car Plate Reader")))
 @SpringBootApplication
 public class UaeCarPalletReaderApplication {
 

--- a/src/main/java/com/example/uaecarpalletreader/controller/PlateRecognitionController.java
+++ b/src/main/java/com/example/uaecarpalletreader/controller/PlateRecognitionController.java
@@ -3,6 +3,12 @@ package com.example.uaecarpalletreader.controller;
 import com.example.uaecarpalletreader.model.PlateExtractionResponse;
 import com.example.uaecarpalletreader.model.PlateExtractionResult;
 import com.example.uaecarpalletreader.service.PlateRecognitionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.CollectionUtils;
@@ -29,8 +35,22 @@ public class PlateRecognitionController {
         this.service = service;
     }
 
+    @Operation(
+            summary = "Extract UAE car plate numbers from uploaded images",
+            description = "Accepts one or more vehicle images, runs OCR, and returns the normalized plate numbers.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Plate numbers successfully extracted",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = PlateExtractionResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content)
+    })
     @PostMapping(value = "/extract", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<PlateExtractionResponse> extract(@RequestPart("images") List<MultipartFile> images) {
+    public ResponseEntity<PlateExtractionResponse> extract(
+            @Parameter(description = "One or more images containing UAE car plates", required = true)
+            @RequestPart("images") List<MultipartFile> images) {
         if (CollectionUtils.isEmpty(images)) {
             throw new ResponseStatusException(BAD_REQUEST, "At least one image must be provided");
         }

--- a/src/main/java/com/example/uaecarpalletreader/model/PlateExtractionResponse.java
+++ b/src/main/java/com/example/uaecarpalletreader/model/PlateExtractionResponse.java
@@ -1,6 +1,11 @@
 package com.example.uaecarpalletreader.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
-public record PlateExtractionResponse(List<PlateExtractionResult> results) {
+@Schema(description = "Aggregated response for a plate extraction request")
+public record PlateExtractionResponse(
+        @Schema(description = "Collection of per-image extraction results")
+        List<PlateExtractionResult> results) {
 }

--- a/src/main/java/com/example/uaecarpalletreader/model/PlateExtractionResult.java
+++ b/src/main/java/com/example/uaecarpalletreader/model/PlateExtractionResult.java
@@ -1,4 +1,10 @@
 package com.example.uaecarpalletreader.model;
 
-public record PlateExtractionResult(String fileName, String rawText, String normalizedPlate) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Plate extraction output for a single uploaded image")
+public record PlateExtractionResult(
+        @Schema(description = "Original name of the processed file", example = "maxima.jpg") String fileName,
+        @Schema(description = "Raw OCR output before normalization", example = "F\\n97344") String rawText,
+        @Schema(description = "Normalized UAE plate number", example = "F 97344") String normalizedPlate) {
 }


### PR DESCRIPTION
## Summary
- upgrade the build to target Java 21 and align the Spring Boot Maven plugin with the platform version
- add springdoc OpenAPI dependency and annotate the API/controller models for Swagger documentation
- refresh the README to mention Java 21 requirements and advertise the Swagger UI endpoints

## Testing
- `mvn test` *(fails: unable to download dependencies from Maven Central due to HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb0951b008332a5839d43aa130477