### PR TITLE
Configure compiler plugin to use Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,14 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>${java.version}</release>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring.boot.version}</version>


### PR DESCRIPTION
## Summary
- add an explicit maven-compiler-plugin configuration to build with the configured Java release

## Testing
- `mvn -q -DskipTests package` *(fails: repository access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb2b0fd0c833295680557462e3d26