### PR TITLE
Configure Maven compiler for current Java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
     <properties>
         <java.version>21</java.version>
         <spring.boot.version>3.3.4</spring.boot.version>
-        <maven.compiler.release>${java.version}</maven.compiler.release>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary
- configure Maven compiler properties to use the configured Java version for source and target levels

## Testing
- mvn -e compile *(fails: repository download blocked in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb3b285348332858aa1c34758ef9a