### PR TITLE
Improve tessdata resolution and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ A Spring Boot 3 (Java 21) REST API for extracting and normalizing UAE car plate 
 
 ### Configuration
 
-By default the application expects the Tesseract runtime to be discoverable on the system path. If you installed the trained data files in a non-default location, expose it via the `TESSDATA_PREFIX` environment variable or provide `tesseract.datapath` as a Spring property:
+At startup the application attempts to locate the tessdata directory by checking the `tesseract.datapath` property, the `TESSDATA_PREFIX` environment (or system) property, and a few common installation directories for Linux and Windows. If none of these contain the requested language file the application will fail fast with an explicit error message instead of surfacing a low level "Invalid memory access" at request time.
+
+If you installed the trained data files in a non-default location, expose it via the `TESSDATA_PREFIX` environment variable or provide `tesseract.datapath` as a Spring property:
 
 ```shell
 java -Dtesseract.datapath=/usr/share/tesseract-ocr/5/tessdata -jar target/uae-car-pallet-reader-0.0.1-SNAPSHOT.jar

--- a/src/main/java/com/example/uaecarpalletreader/config/TesseractConfiguration.java
+++ b/src/main/java/com/example/uaecarpalletreader/config/TesseractConfiguration.java
@@ -8,6 +8,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
 @Configuration
 public class TesseractConfiguration {
 
@@ -22,15 +29,71 @@ public class TesseractConfiguration {
     @Bean
     public Tesseract tesseract() throws TesseractException {
         Tesseract tesseract = new Tesseract();
-        if (dataPath != null && !dataPath.isBlank()) {
-            log.info("Configuring Tesseract data path: {}", dataPath);
-            tesseract.setDatapath(dataPath);
+        String resolvedDataPath = resolveDataPath();
+        if (resolvedDataPath != null) {
+            log.info("Configuring Tesseract data path: {}", resolvedDataPath);
+            tesseract.setDatapath(resolvedDataPath);
         } else {
-            log.warn("No explicit tesseract.datapath configured. Using default search paths.");
+            String message = String.format(Locale.ROOT,
+                    "Unable to locate Tesseract language data for '%s'. " +
+                            "Provide it via the tesseract.datapath property or the TESSDATA_PREFIX environment variable.",
+                    language);
+            log.error(message);
+            throw new IllegalStateException(message);
         }
         tesseract.setLanguage(language);
         tesseract.setOcrEngineMode(1); // LSTM only
         tesseract.setPageSegMode(6); // Assume a block of text
         return tesseract;
+    }
+
+    private String resolveDataPath() {
+        List<String> candidates = new ArrayList<>();
+        if (dataPath != null && !dataPath.isBlank()) {
+            candidates.add(dataPath);
+        }
+        String envCandidate = System.getenv("TESSDATA_PREFIX");
+        if (envCandidate != null && !envCandidate.isBlank()) {
+            candidates.add(envCandidate);
+        }
+        String systemPropertyCandidate = System.getProperty("TESSDATA_PREFIX");
+        if (systemPropertyCandidate != null && !systemPropertyCandidate.isBlank()) {
+            candidates.add(systemPropertyCandidate);
+        }
+
+        candidates.add("/usr/share/tesseract-ocr/5/tessdata");
+        candidates.add("/usr/share/tesseract-ocr/4.00/tessdata");
+        candidates.add("C:/Program Files/Tesseract-OCR/tessdata");
+
+        for (String candidate : candidates) {
+            Path validPath = validateCandidate(candidate);
+            if (validPath != null) {
+                return validPath.toString();
+            }
+        }
+        return null;
+    }
+
+    private Path validateCandidate(String candidate) {
+        Path basePath = Paths.get(candidate).normalize();
+        if (!Files.isDirectory(basePath)) {
+            return null;
+        }
+
+        Path directLanguageFile = basePath.resolve(language + ".traineddata");
+        if (Files.isRegularFile(directLanguageFile)) {
+            return basePath;
+        }
+
+        Path tessdataDirectory = basePath.resolve("tessdata");
+        if (Files.isDirectory(tessdataDirectory)) {
+            Path nestedLanguageFile = tessdataDirectory.resolve(language + ".traineddata");
+            if (Files.isRegularFile(nestedLanguageFile)) {
+                return tessdataDirectory;
+            }
+        }
+
+        log.debug("Tesseract data path candidate '{}' does not contain {}.traineddata", candidate, language);
+        return null;
     }
 }

--- a/src/main/java/com/example/uaecarpalletreader/service/PlateRecognitionService.java
+++ b/src/main/java/com/example/uaecarpalletreader/service/PlateRecognitionService.java
@@ -55,6 +55,15 @@ public class PlateRecognitionService {
         } catch (TesseractException e) {
             log.error("Tesseract OCR failed for {}", fileName, e);
             throw new IllegalStateException("Failed to extract text from " + fileName, e);
+        } catch (Error e) {
+            if ("Invalid memory access".equalsIgnoreCase(e.getMessage())) {
+                String message = String.format(
+                        "Tesseract native layer failed while processing %s. Verify that the tessdata directory contains %s.traineddata.",
+                        fileName, tesseract.getLanguage());
+                log.error(message, e);
+                throw new IllegalStateException(message, e);
+            }
+            throw e;
         }
     }
 


### PR DESCRIPTION
## Summary
- add tessdata resolution that checks configured values, environment variables, and common install locations before starting the app
- guard the OCR service against invalid memory access errors with clearer operator guidance
- document the tessdata discovery behaviour in the README

## Testing
- mvn test *(fails: Maven Central returned 403 while downloading Spring Boot dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb5fac910833290a29b3f38ca9705