### PR TITLE
Add structured plate metadata extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,18 @@ Sample response:
     {
       "fileName": "maxima.jpg",
       "rawText": "F\n97344",
-      "normalizedPlate": "F 97344"
+      "normalizedPlate": "F 97344",
+      "city": null,
+      "characters": "F",
+      "number": "97344"
     },
     {
       "fileName": "lexus.jpg",
       "rawText": "Dubai\nBB 19849",
-      "normalizedPlate": "BB 19849"
+      "normalizedPlate": "BB 19849",
+      "city": "Dubai",
+      "characters": "BB",
+      "number": "19849"
     }
   ]
 }

--- a/src/main/java/com/example/uaecarpalletreader/model/PlateExtractionResult.java
+++ b/src/main/java/com/example/uaecarpalletreader/model/PlateExtractionResult.java
@@ -6,5 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record PlateExtractionResult(
         @Schema(description = "Original name of the processed file", example = "maxima.jpg") String fileName,
         @Schema(description = "Raw OCR output before normalization", example = "F\\n97344") String rawText,
-        @Schema(description = "Normalized UAE plate number", example = "F 97344") String normalizedPlate) {
+        @Schema(description = "Normalized UAE plate number", example = "F 97344") String normalizedPlate,
+        @Schema(description = "Detected emirate or city when available", example = "Dubai") String city,
+        @Schema(description = "Letter sequence extracted from the plate", example = "F") String characters,
+        @Schema(description = "Numeric sequence extracted from the plate", example = "97344") String number) {
 }

--- a/src/main/java/com/example/uaecarpalletreader/service/PlateRecognitionService.java
+++ b/src/main/java/com/example/uaecarpalletreader/service/PlateRecognitionService.java
@@ -2,6 +2,7 @@ package com.example.uaecarpalletreader.service;
 
 import com.example.uaecarpalletreader.model.PlateExtractionResult;
 import com.example.uaecarpalletreader.util.PlateNumberNormalizer;
+import com.example.uaecarpalletreader.util.PlateNumberNormalizer.NormalizedPlate;
 import jakarta.annotation.PostConstruct;
 import net.sourceforge.tess4j.Tesseract;
 import net.sourceforge.tess4j.TesseractException;
@@ -51,8 +52,14 @@ public class PlateRecognitionService {
 
             BufferedImage preprocessed = preprocess(bufferedImage);
             String rawText = tesseract.doOCR(preprocessed);
-            String normalized = PlateNumberNormalizer.normalize(rawText);
-            return new PlateExtractionResult(fileName, rawText != null ? rawText.trim() : null, normalized);
+            NormalizedPlate normalized = PlateNumberNormalizer.normalize(rawText);
+            return new PlateExtractionResult(
+                    fileName,
+                    rawText != null ? rawText.trim() : null,
+                    normalized.normalizedPlate(),
+                    normalized.city(),
+                    normalized.letters(),
+                    normalized.number());
         } catch (IOException e) {
             log.error("Failed to read image {}", fileName, e);
             throw new IllegalStateException("Failed to read image " + fileName, e);

--- a/src/main/java/com/example/uaecarpalletreader/util/PlateNumberNormalizer.java
+++ b/src/main/java/com/example/uaecarpalletreader/util/PlateNumberNormalizer.java
@@ -1,20 +1,38 @@
 package com.example.uaecarpalletreader.util;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class PlateNumberNormalizer {
 
     private static final Pattern ALPHANUMERIC_PATTERN = Pattern.compile("[A-Za-z0-9]+");
-    private static final Pattern DUBAI_PREFIX_PATTERN = Pattern.compile("(?i)(dubai\\s*)");
+    private static final List<EmiratePattern> EMIRATE_PATTERNS = List.of(
+            new EmiratePattern(List.of("ABU", "DHABI"), "Abu Dhabi"),
+            new EmiratePattern(List.of("ABUDHABI"), "Abu Dhabi"),
+            new EmiratePattern(List.of("DUBAI"), "Dubai"),
+            new EmiratePattern(List.of("DXB"), "Dubai"),
+            new EmiratePattern(List.of("SHARJAH"), "Sharjah"),
+            new EmiratePattern(List.of("SHJ"), "Sharjah"),
+            new EmiratePattern(List.of("AJMAN"), "Ajman"),
+            new EmiratePattern(List.of("AJM"), "Ajman"),
+            new EmiratePattern(List.of("UMM", "AL", "QUWAIN"), "Umm Al Quwain"),
+            new EmiratePattern(List.of("UAQ"), "Umm Al Quwain"),
+            new EmiratePattern(List.of("RAS", "AL", "KHAIMAH"), "Ras Al Khaimah"),
+            new EmiratePattern(List.of("RAK"), "Ras Al Khaimah"),
+            new EmiratePattern(List.of("FUJAIRAH"), "Fujairah"),
+            new EmiratePattern(List.of("FUJ"), "Fujairah")
+    );
 
     private PlateNumberNormalizer() {
     }
 
-    public static String normalize(String rawText) {
+    public static NormalizedPlate normalize(String rawText) {
         if (rawText == null) {
-            return null;
+            return new NormalizedPlate(null, null, null, null);
         }
 
         String cleaned = rawText
@@ -24,20 +42,89 @@ public final class PlateNumberNormalizer {
                 .trim();
 
         if (cleaned.isEmpty()) {
-            return null;
+            return new NormalizedPlate(null, null, null, null);
         }
-
-        cleaned = DUBAI_PREFIX_PATTERN.matcher(cleaned).replaceAll("");
 
         Matcher matcher = ALPHANUMERIC_PATTERN.matcher(cleaned);
-        StringBuilder builder = new StringBuilder();
+        List<String> tokens = new ArrayList<>();
         while (matcher.find()) {
-            if (!builder.isEmpty()) {
-                builder.append(' ');
-            }
-            builder.append(matcher.group().toUpperCase(Locale.ROOT));
+            tokens.add(matcher.group().toUpperCase(Locale.ROOT));
         }
 
-        return builder.length() == 0 ? null : builder.toString();
+        if (tokens.isEmpty()) {
+            return new NormalizedPlate(null, null, null, null);
+        }
+
+        EmirateMatch emirateMatch = findEmirate(tokens);
+        String city = emirateMatch != null ? emirateMatch.emirate() : null;
+
+        List<String> filteredTokens = new ArrayList<>(tokens);
+        if (emirateMatch != null) {
+            for (int i = 0; i < emirateMatch.length(); i++) {
+                filteredTokens.set(emirateMatch.startIndex() + i, null);
+            }
+        }
+        filteredTokens.removeIf(Objects::isNull);
+
+        if (filteredTokens.isEmpty()) {
+            return new NormalizedPlate(null, city, null, null);
+        }
+
+        String normalized = String.join(" ", filteredTokens);
+        String characters = joinTokens(filteredTokens.stream()
+                .filter(token -> token.chars().allMatch(Character::isLetter))
+                .toList());
+
+        String number = joinTokens(filteredTokens.stream()
+                .filter(token -> token.chars().allMatch(Character::isDigit))
+                .toList());
+
+        return new NormalizedPlate(normalized, city,
+                characters.isBlank() ? null : characters,
+                number.isBlank() ? null : number);
+    }
+
+    private static EmirateMatch findEmirate(List<String> tokens) {
+        for (EmiratePattern pattern : EMIRATE_PATTERNS) {
+            EmirateMatch match = findPattern(tokens, pattern);
+            if (match != null) {
+                return match;
+            }
+        }
+        return null;
+    }
+
+    private static EmirateMatch findPattern(List<String> tokens, EmiratePattern pattern) {
+        List<String> patternTokens = pattern.tokens();
+        int maxStart = tokens.size() - patternTokens.size();
+        for (int start = 0; start <= maxStart; start++) {
+            boolean matches = true;
+            for (int offset = 0; offset < patternTokens.size(); offset++) {
+                if (!Objects.equals(tokens.get(start + offset), patternTokens.get(offset))) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) {
+                return new EmirateMatch(pattern.displayName(), start, patternTokens.size());
+            }
+        }
+        return null;
+    }
+
+    private static String joinTokens(List<String> tokens) {
+        if (tokens.isEmpty()) {
+            return "";
+        }
+        return String.join(" ", tokens);
+    }
+
+    private record EmiratePattern(List<String> tokens, String displayName) {
+    }
+
+    public record NormalizedPlate(String normalizedPlate, String city, String letters, String number) {
+    }
+
+    private record EmirateMatch(String emirate, int startIndex, int length) {
     }
 }

--- a/src/test/java/com/example/uaecarpalletreader/util/PlateNumberNormalizerTest.java
+++ b/src/test/java/com/example/uaecarpalletreader/util/PlateNumberNormalizerTest.java
@@ -8,18 +8,37 @@ class PlateNumberNormalizerTest {
 
     @Test
     void shouldNormalizePlateWithDubaiPrefix() {
-        String normalized = PlateNumberNormalizer.normalize("Dubai bb 19849\n");
-        assertThat(normalized).isEqualTo("BB 19849");
+        PlateNumberNormalizer.NormalizedPlate normalized = PlateNumberNormalizer.normalize("Dubai bb 19849\n");
+        assertThat(normalized.normalizedPlate()).isEqualTo("BB 19849");
+        assertThat(normalized.city()).isEqualTo("Dubai");
+        assertThat(normalized.characters()).isEqualTo("BB");
+        assertThat(normalized.number()).isEqualTo("19849");
     }
 
     @Test
     void shouldNormalizeWithSpecialCharacters() {
-        String normalized = PlateNumberNormalizer.normalize("F-97344");
-        assertThat(normalized).isEqualTo("F 97344");
+        PlateNumberNormalizer.NormalizedPlate normalized = PlateNumberNormalizer.normalize("F-97344");
+        assertThat(normalized.normalizedPlate()).isEqualTo("F 97344");
+        assertThat(normalized.city()).isNull();
+        assertThat(normalized.characters()).isEqualTo("F");
+        assertThat(normalized.number()).isEqualTo("97344");
     }
 
     @Test
     void shouldReturnNullForEmpty() {
-        assertThat(PlateNumberNormalizer.normalize("   ")).isNull();
+        PlateNumberNormalizer.NormalizedPlate normalized = PlateNumberNormalizer.normalize("   ");
+        assertThat(normalized.normalizedPlate()).isNull();
+        assertThat(normalized.city()).isNull();
+        assertThat(normalized.characters()).isNull();
+        assertThat(normalized.number()).isNull();
+    }
+
+    @Test
+    void shouldExtractAjmanCityFromAbbreviation() {
+        PlateNumberNormalizer.NormalizedPlate normalized = PlateNumberNormalizer.normalize("Ajm 12345");
+        assertThat(normalized.city()).isEqualTo("Ajman");
+        assertThat(normalized.normalizedPlate()).isEqualTo("12345");
+        assertThat(normalized.number()).isEqualTo("12345");
+        assertThat(normalized.characters()).isNull();
     }
 }


### PR DESCRIPTION
## Summary
- extend the plate normalizer to detect emirate names, letter sequences, and numbers while keeping a cleaned plate string
- surface the new city, characters, and number fields in the API response model and documentation
- update and expand unit tests to cover the richer normalization behavior

## Testing
- `mvn -q test` *(fails: unable to download Spring Boot dependencies due to HTTP 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dfbb25c7ec8332ae3e92fd93097c00