### PR TITLE
Improve plate normalization for noisy OCR output

### DIFF
--- a/src/test/java/com/example/uaecarpalletreader/util/PlateNumberNormalizerTest.java
+++ b/src/test/java/com/example/uaecarpalletreader/util/PlateNumberNormalizerTest.java
@@ -41,4 +41,22 @@ class PlateNumberNormalizerTest {
         assertThat(normalized.number()).isEqualTo("12345");
         assertThat(normalized.characters()).isNull();
     }
+
+    @Test
+    void shouldCollapseSingleDigitSequencesIntoNumber() {
+        PlateNumberNormalizer.NormalizedPlate normalized = PlateNumberNormalizer.normalize("Sharjah B 1 2 3 4");
+        assertThat(normalized.city()).isEqualTo("Sharjah");
+        assertThat(normalized.normalizedPlate()).isEqualTo("B 1234");
+        assertThat(normalized.characters()).isEqualTo("B");
+        assertThat(normalized.number()).isEqualTo("1234");
+    }
+
+    @Test
+    void shouldReturnNullWhenOnlyNoisySingleDigitTokensDetected() {
+        PlateNumberNormalizer.NormalizedPlate normalized = PlateNumberNormalizer.normalize("foo 1 a 2 b 3 c 4 d 5");
+        assertThat(normalized.normalizedPlate()).isNull();
+        assertThat(normalized.number()).isNull();
+        assertThat(normalized.characters()).isNull();
+        assertThat(normalized.city()).isNull();
+    }
 }


### PR DESCRIPTION
## Summary
- collapse isolated digit tokens so OCR output like "1 2 3" becomes a single plate number
- detect noisy OCR results that only contain scattered single digits and return a null normalization instead of garbage text
- expand the normalizer unit tests to cover digit collapsing and noisy single-digit scenarios

## Testing
- Not run (Maven dependencies cannot be downloaded in the offline environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfbd529b048332a61ad046a75b3b9e