### PR TITLE
Add pluggable plate detection pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,18 @@ A Spring Boot 3 (Java 21) REST API for extracting and normalizing UAE car plate 
 
 - Accepts multiple images in a single multipart/form-data request.
 - Uses [Tess4J](https://tess4j.sourceforge.net/) as a Java wrapper around the Tesseract OCR engine.
-- Applies lightweight grayscale and contrast preprocessing before running OCR.
+- Applies lightweight grayscale, sharpening, and adaptive-style thresholding before running OCR.
 - Normalizes the OCR output by removing noise, duplicates, and Dubai-specific prefixes.
 - Provides per-image extraction results including the raw OCR text and the cleaned plate number.
+
+## Processing pipeline
+
+1. **Plate detection** – the default implementation treats the entire image as a candidate plate. Swap the `PlateDetector` bean with a YOLO-based implementation to take advantage of proper localization.
+2. **ROI cropping** – each detected bounding box is cropped, ensuring only the plate region reaches OCR.
+3. **Image preprocessing** – grayscale conversion, contrast stretching, sharpening, and binary thresholding improve character visibility without requiring native OpenCV bindings.
+4. **OCR & post-processing** – Tesseract extracts raw text which is then normalised using regex and emirate-aware heuristics to produce the final plate, city, letters, and digits.
+
+The service scores multiple candidates and returns the most plausible match, mirroring the recommended YOLO → ROI → preprocessing → Tesseract → normalization workflow.
 
 ## Getting Started
 

--- a/src/main/java/com/example/uaecarpalletreader/config/DetectorConfiguration.java
+++ b/src/main/java/com/example/uaecarpalletreader/config/DetectorConfiguration.java
@@ -1,0 +1,26 @@
+package com.example.uaecarpalletreader.config;
+
+import com.example.uaecarpalletreader.service.detection.NoOpPlateDetector;
+import com.example.uaecarpalletreader.service.detection.PlateDetector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Provides a default {@link PlateDetector}. Projects that want to use a
+ * specialised detector such as a YOLO model can replace this bean with their
+ * own configuration.
+ */
+@Configuration
+public class DetectorConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(DetectorConfiguration.class);
+
+    @Bean
+    public PlateDetector plateDetector() {
+        log.info("Using fallback plate detector. Configure a YOLO-based implementation for higher accuracy.");
+        return new NoOpPlateDetector();
+    }
+}
+

--- a/src/main/java/com/example/uaecarpalletreader/model/BoundingBox.java
+++ b/src/main/java/com/example/uaecarpalletreader/model/BoundingBox.java
@@ -1,0 +1,26 @@
+package com.example.uaecarpalletreader.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Simple bounding box representation used to describe a detected plate region
+ * inside a source image. Coordinates follow the image pixel grid with the
+ * origin located in the top-left corner.
+ */
+@Schema(description = "Axis-aligned rectangle describing a detected plate region")
+public record BoundingBox(
+        @Schema(description = "X coordinate of the top-left corner", example = "42") int x,
+        @Schema(description = "Y coordinate of the top-left corner", example = "128") int y,
+        @Schema(description = "Bounding box width in pixels", example = "180") int width,
+        @Schema(description = "Bounding box height in pixels", example = "60") int height) {
+
+    public BoundingBox {
+        if (width <= 0) {
+            throw new IllegalArgumentException("Bounding box width must be positive");
+        }
+        if (height <= 0) {
+            throw new IllegalArgumentException("Bounding box height must be positive");
+        }
+    }
+}
+

--- a/src/main/java/com/example/uaecarpalletreader/service/PlateRecognitionService.java
+++ b/src/main/java/com/example/uaecarpalletreader/service/PlateRecognitionService.java
@@ -1,6 +1,9 @@
 package com.example.uaecarpalletreader.service;
 
+import com.example.uaecarpalletreader.model.BoundingBox;
 import com.example.uaecarpalletreader.model.PlateExtractionResult;
+import com.example.uaecarpalletreader.service.detection.PlateDetector;
+import com.example.uaecarpalletreader.util.ImagePreprocessor;
 import com.example.uaecarpalletreader.util.PlateNumberNormalizer;
 import com.example.uaecarpalletreader.util.PlateNumberNormalizer.NormalizedPlate;
 import jakarta.annotation.PostConstruct;
@@ -13,11 +16,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.imageio.ImageIO;
-import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.awt.image.RescaleOp;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
 
 @Service
 public class PlateRecognitionService {
@@ -26,11 +31,14 @@ public class PlateRecognitionService {
 
     private final Tesseract tesseract;
     private final String language;
+    private final PlateDetector plateDetector;
 
     public PlateRecognitionService(Tesseract tesseract,
-                                   @Value("${tesseract.language:eng}") String language) {
+                                   @Value("${tesseract.language:eng}") String language,
+                                   PlateDetector plateDetector) {
         this.tesseract = tesseract;
         this.language = language;
+        this.plateDetector = plateDetector;
     }
 
     @PostConstruct
@@ -50,12 +58,15 @@ public class PlateRecognitionService {
                 throw new IllegalArgumentException("Unsupported image type for file: " + fileName);
             }
 
-            BufferedImage preprocessed = preprocess(bufferedImage);
-            String rawText = tesseract.doOCR(preprocessed);
-            NormalizedPlate normalized = PlateNumberNormalizer.normalize(rawText);
+            PlateCandidate bestCandidate = evaluateCandidates(bufferedImage);
+            if (bestCandidate == null) {
+                throw new IllegalStateException("Unable to extract plate information from " + fileName);
+            }
+
+            NormalizedPlate normalized = bestCandidate.normalized();
             return new PlateExtractionResult(
                     fileName,
-                    rawText != null ? rawText.trim() : null,
+                    bestCandidate.rawText(),
                     normalized.normalizedPlate(),
                     normalized.city(),
                     normalized.letters(),
@@ -78,15 +89,80 @@ public class PlateRecognitionService {
         }
     }
 
-    private BufferedImage preprocess(BufferedImage input) {
-        BufferedImage grayscale = new BufferedImage(input.getWidth(), input.getHeight(), BufferedImage.TYPE_BYTE_GRAY);
-        Graphics2D g = grayscale.createGraphics();
-        g.drawImage(input, 0, 0, null);
-        g.dispose();
+    private PlateCandidate evaluateCandidates(BufferedImage image) throws TesseractException {
+        List<BoundingBox> boxes = new ArrayList<>(plateDetector.detect(image));
+        if (boxes.isEmpty()) {
+            boxes.add(new BoundingBox(0, 0, image.getWidth(), image.getHeight()));
+        }
 
-        RescaleOp rescaleOp = new RescaleOp(1.2f, 15, null);
-        rescaleOp.filter(grayscale, grayscale);
+        List<PlateCandidate> candidates = new ArrayList<>();
+        for (BoundingBox box : boxes) {
+            BufferedImage cropped = crop(image, box);
+            if (cropped.getWidth() < 20 || cropped.getHeight() < 20) {
+                log.debug("Skipping tiny candidate {}", box);
+                continue;
+            }
+            BufferedImage preprocessed = ImagePreprocessor.preprocess(cropped);
+            String rawText = safeOcr(preprocessed);
+            if (rawText == null || rawText.isBlank()) {
+                log.debug("OCR returned empty result for candidate {}", box);
+                continue;
+            }
+            NormalizedPlate normalized = PlateNumberNormalizer.normalize(rawText);
+            candidates.add(new PlateCandidate(rawText.trim(), normalized, box));
+        }
 
-        return grayscale;
+        if (candidates.isEmpty()) {
+            return null;
+        }
+
+        return candidates.stream()
+                .max(Comparator.comparingInt(this::scoreCandidate))
+                .orElse(null);
+    }
+
+    private BufferedImage crop(BufferedImage source, BoundingBox box) {
+        int x = clamp(box.x(), 0, source.getWidth() - 1);
+        int y = clamp(box.y(), 0, source.getHeight() - 1);
+        int width = clamp(box.width(), 1, source.getWidth() - x);
+        int height = clamp(box.height(), 1, source.getHeight() - y);
+        return source.getSubimage(x, y, width, height);
+    }
+
+    private int clamp(int value, int min, int max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    private String safeOcr(BufferedImage image) throws TesseractException {
+        String raw = tesseract.doOCR(image);
+        return raw != null ? raw.replace('\u0000', ' ').trim() : null;
+    }
+
+    private int scoreCandidate(PlateCandidate candidate) {
+        NormalizedPlate normalized = candidate.normalized();
+        int score = 0;
+        if (normalized.normalizedPlate() != null) {
+            score += normalized.normalizedPlate().replace(" ", "").length() * 2;
+        }
+        if (normalized.number() != null) {
+            score += normalized.number().length() * 3;
+        }
+        if (normalized.letters() != null) {
+            score += normalized.letters().replace(" ", "").length() * 2;
+        }
+        if (normalized.city() != null) {
+            score += 2;
+        }
+
+        long digitCount = candidate.rawText().chars().filter(Character::isDigit).count();
+        long letterCount = candidate.rawText().chars().filter(Character::isLetter).count();
+        score += (int) (digitCount + letterCount);
+        return score;
+    }
+
+    private record PlateCandidate(String rawText, NormalizedPlate normalized, BoundingBox boundingBox) {
+        PlateCandidate {
+            Objects.requireNonNull(normalized, "normalized");
+        }
     }
 }

--- a/src/main/java/com/example/uaecarpalletreader/service/detection/NoOpPlateDetector.java
+++ b/src/main/java/com/example/uaecarpalletreader/service/detection/NoOpPlateDetector.java
@@ -1,0 +1,23 @@
+package com.example.uaecarpalletreader.service.detection;
+
+import com.example.uaecarpalletreader.model.BoundingBox;
+
+import java.awt.image.BufferedImage;
+import java.util.List;
+
+/**
+ * Default detector that simply returns the whole image as a single candidate
+ * plate region. This acts as a safe fallback when no dedicated detector
+ * (e.g. YOLO model) is available.
+ */
+public class NoOpPlateDetector implements PlateDetector {
+
+    @Override
+    public List<BoundingBox> detect(BufferedImage image) {
+        if (image == null) {
+            return List.of();
+        }
+        return List.of(new BoundingBox(0, 0, image.getWidth(), image.getHeight()));
+    }
+}
+

--- a/src/main/java/com/example/uaecarpalletreader/service/detection/PlateDetector.java
+++ b/src/main/java/com/example/uaecarpalletreader/service/detection/PlateDetector.java
@@ -1,0 +1,23 @@
+package com.example.uaecarpalletreader.service.detection;
+
+import com.example.uaecarpalletreader.model.BoundingBox;
+
+import java.awt.image.BufferedImage;
+import java.util.List;
+
+/**
+ * Detects one or more license plate regions inside an image. Implementations
+ * can rely on deep learning models (e.g. YOLO) or any classical computer
+ * vision technique. The interface is intentionally minimal so alternative
+ * detectors can be wired in through Spring configuration.
+ */
+public interface PlateDetector {
+
+    /**
+     * @param image input vehicle image
+     * @return list of candidate plate regions. The list can be empty when no
+     * detections are produced.
+     */
+    List<BoundingBox> detect(BufferedImage image);
+}
+

--- a/src/main/java/com/example/uaecarpalletreader/util/ImagePreprocessor.java
+++ b/src/main/java/com/example/uaecarpalletreader/util/ImagePreprocessor.java
@@ -1,0 +1,82 @@
+package com.example.uaecarpalletreader.util;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.awt.image.ConvolveOp;
+import java.awt.image.Kernel;
+import java.awt.image.RescaleOp;
+
+/**
+ * Image preprocessing utilities used before sending a plate region to
+ * Tesseract. The steps implemented here are deliberately lightweight so they
+ * work without any native dependencies: grayscale conversion, contrast
+ * stretching, edge sharpening and global thresholding.
+ */
+public final class ImagePreprocessor {
+
+    private ImagePreprocessor() {
+    }
+
+    public static BufferedImage preprocess(BufferedImage input) {
+        if (input == null) {
+            throw new IllegalArgumentException("Input image cannot be null");
+        }
+
+        BufferedImage grayscale = toGrayscale(input);
+        BufferedImage enhanced = stretchContrast(grayscale);
+        BufferedImage sharpened = sharpen(enhanced);
+        return applyBinaryThreshold(sharpened);
+    }
+
+    private static BufferedImage toGrayscale(BufferedImage input) {
+        BufferedImage grayscale = new BufferedImage(input.getWidth(), input.getHeight(), BufferedImage.TYPE_BYTE_GRAY);
+        Graphics2D g = grayscale.createGraphics();
+        g.setComposite(AlphaComposite.Src);
+        g.drawImage(input, 0, 0, null);
+        g.dispose();
+        return grayscale;
+    }
+
+    private static BufferedImage stretchContrast(BufferedImage input) {
+        RescaleOp rescaleOp = new RescaleOp(1.6f, -20f, null);
+        rescaleOp.filter(input, input);
+        return input;
+    }
+
+    private static BufferedImage sharpen(BufferedImage input) {
+        float[] sharpenKernel = new float[]{
+                0f, -1f, 0f,
+                -1f, 5f, -1f,
+                0f, -1f, 0f
+        };
+        ConvolveOp convolve = new ConvolveOp(new Kernel(3, 3, sharpenKernel), ConvolveOp.EDGE_NO_OP, null);
+        BufferedImage destination = new BufferedImage(input.getWidth(), input.getHeight(), BufferedImage.TYPE_BYTE_GRAY);
+        convolve.filter(input, destination);
+        return destination;
+    }
+
+    private static BufferedImage applyBinaryThreshold(BufferedImage input) {
+        int width = input.getWidth();
+        int height = input.getHeight();
+        BufferedImage thresholded = new BufferedImage(width, height, BufferedImage.TYPE_BYTE_GRAY);
+
+        long total = 0;
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                int gray = input.getRaster().getSample(x, y, 0);
+                total += gray;
+            }
+        }
+        int threshold = (int) (total / Math.max(1, width * height));
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                int gray = input.getRaster().getSample(x, y, 0);
+                int value = gray >= threshold ? 255 : 0;
+                thresholded.getRaster().setSample(x, y, 0, value);
+            }
+        }
+        return thresholded;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a pluggable plate detector bean with a default fallback implementation
- preprocess detected regions with grayscale, sharpening, and thresholding before OCR
- update documentation to describe the YOLO → ROI → preprocessing → Tesseract pipeline

## Testing
- mvn test *(fails: unable to download org.springframework.boot:spring-boot-dependencies:3.3.4 due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc08e6f4483329ce32540cd6e50b1