### PR TITLE
Improve plate normalization scoring

### DIFF
--- a/src/test/java/com/example/uaecarpalletreader/util/PlateNumberNormalizerTest.java
+++ b/src/test/java/com/example/uaecarpalletreader/util/PlateNumberNormalizerTest.java
@@ -59,4 +59,28 @@ class PlateNumberNormalizerTest {
         assertThat(normalized.characters()).isNull();
         assertThat(normalized.city()).isNull();
     }
+
+    @Test
+    void shouldPreferPlausibleTokenWindowAroundDigits() {
+        String rawText = """
+                I ie Ve
+                i ij ' ree
+                ~ a —_— a
+                SS | Se
+                a (4 a
+                Soe Sa = a  .
+                a
+                eee 19949 BY
+                a
+                oe = oe
+                TEES aL nn
+                " ROR! | ESOS rs og
+                """;
+
+        PlateNumberNormalizer.NormalizedPlate normalized = PlateNumberNormalizer.normalize(rawText);
+
+        assertThat(normalized.normalizedPlate()).isEqualTo("BY 19949");
+        assertThat(normalized.characters()).isEqualTo("BY");
+        assertThat(normalized.number()).isEqualTo("19949");
+    }
 }


### PR DESCRIPTION
## Summary
- add scoring-based selection of candidate token windows when normalizing OCR output
- reorder prioritized tokens to prefer letters before digits and expose helper utilities
- cover noisy OCR scenario with a new unit test to ensure BY 19949 is extracted

## Testing
- `mvn test` *(fails: unable to download dependencies due to HTTP 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc57f00408332a21f6ab65395f390