### PR TITLE
Add OpenCV-based ANPR pipeline and API endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,16 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.openpnp</groupId>
+            <artifactId>opencv</artifactId>
+            <version>4.7.0-0</version>
+        </dependency>
+        <dependency>
+            <groupId>nu.pattern</groupId>
+            <artifactId>opencv</artifactId>
+            <version>4.7.0-0</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>

--- a/src/main/java/com/example/uaecarpalletreader/UaeCarPalletReaderApplication.java
+++ b/src/main/java/com/example/uaecarpalletreader/UaeCarPalletReaderApplication.java
@@ -3,8 +3,10 @@ package com.example.uaecarpalletreader;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
+import com.example.uaecarpalletreader.config.AnprProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @OpenAPIDefinition(
         info = @Info(
@@ -13,6 +15,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
                 description = "REST API for extracting and normalizing UAE vehicle plate numbers from uploaded images.",
                 contact = @Contact(name = "UAE Car Plate Reader")))
 @SpringBootApplication
+@EnableConfigurationProperties(AnprProperties.class)
 public class UaeCarPalletReaderApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/uaecarpalletreader/config/AnprProperties.java
+++ b/src/main/java/com/example/uaecarpalletreader/config/AnprProperties.java
@@ -1,0 +1,71 @@
+package com.example.uaecarpalletreader.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "anpr")
+public class AnprProperties {
+
+    private boolean enabled = true;
+    private String modelPath = "./models/yolov8n_plate.onnx";
+    private int inputSize = 640;
+    private double confThreshold = 0.25;
+    private double nmsThreshold = 0.45;
+    private String tessdataPath = "C:/Program Files/Tesseract-OCR/tessdata";
+    private String languages = "ara+eng";
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getModelPath() {
+        return modelPath;
+    }
+
+    public void setModelPath(String modelPath) {
+        this.modelPath = modelPath;
+    }
+
+    public int getInputSize() {
+        return inputSize;
+    }
+
+    public void setInputSize(int inputSize) {
+        this.inputSize = inputSize;
+    }
+
+    public double getConfThreshold() {
+        return confThreshold;
+    }
+
+    public void setConfThreshold(double confThreshold) {
+        this.confThreshold = confThreshold;
+    }
+
+    public double getNmsThreshold() {
+        return nmsThreshold;
+    }
+
+    public void setNmsThreshold(double nmsThreshold) {
+        this.nmsThreshold = nmsThreshold;
+    }
+
+    public String getTessdataPath() {
+        return tessdataPath;
+    }
+
+    public void setTessdataPath(String tessdataPath) {
+        this.tessdataPath = tessdataPath;
+    }
+
+    public String getLanguages() {
+        return languages;
+    }
+
+    public void setLanguages(String languages) {
+        this.languages = languages;
+    }
+}

--- a/src/main/java/com/example/uaecarpalletreader/controller/AnprController.java
+++ b/src/main/java/com/example/uaecarpalletreader/controller/AnprController.java
@@ -1,0 +1,136 @@
+package com.example.uaecarpalletreader.controller;
+
+import com.example.uaecarpalletreader.config.AnprProperties;
+import com.example.uaecarpalletreader.model.anpr.AnprHealthResponse;
+import com.example.uaecarpalletreader.model.anpr.AnprInferenceResponse;
+import com.example.uaecarpalletreader.model.anpr.AnprPlateResponse;
+import com.example.uaecarpalletreader.model.anpr.AnprServiceResult;
+import com.example.uaecarpalletreader.model.anpr.Base64ImageRequest;
+import com.example.uaecarpalletreader.model.anpr.PlateReading;
+import com.example.uaecarpalletreader.service.anpr.AnprService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
+
+@RestController
+@RequestMapping("/api/anpr")
+@Tag(name = "ANPR", description = "Automatic Number Plate Recognition endpoints")
+public class AnprController {
+
+    private static final Logger log = LoggerFactory.getLogger(AnprController.class);
+
+    private final AnprProperties properties;
+    private final AnprService service;
+
+    public AnprController(AnprProperties properties, AnprService service) {
+        this.properties = properties;
+        this.service = service;
+    }
+
+    @PostMapping(value = "/infer", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "Run ANPR on an uploaded image", description = "Accepts a single vehicle image and returns detected plates with OCR results.")
+    public ResponseEntity<AnprInferenceResponse> inferFromMultipart(@RequestPart("image") MultipartFile image) {
+        return runInference(readImageFromMultipart(image));
+    }
+
+    @PostMapping(value = "/infer", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "Run ANPR on a base64 encoded image", description = "Accepts a base64 encoded image and returns detected plates with OCR results.")
+    public ResponseEntity<AnprInferenceResponse> inferFromBase64(@Valid @RequestBody Base64ImageRequest request) {
+        return runInference(readImageFromBase64(request.image()));
+    }
+
+    @GetMapping("/health")
+    @Operation(summary = "Retrieve ANPR service health state")
+    public ResponseEntity<AnprHealthResponse> health() {
+        return ResponseEntity.ok(new AnprHealthResponse(properties.isEnabled(), properties.getModelPath()));
+    }
+
+    private ResponseEntity<AnprInferenceResponse> runInference(BufferedImage image) {
+        if (!properties.isEnabled()) {
+            throw new ResponseStatusException(SERVICE_UNAVAILABLE, "ANPR service is disabled");
+        }
+        try {
+            AnprServiceResult result = service.detectAndRead(image);
+            AnprInferenceResponse response = new AnprInferenceResponse(mapPlates(result), result.modelTimeMs(), result.ocrTimeMs());
+            return ResponseEntity.ok(response);
+        } catch (IllegalStateException ex) {
+            log.error("ANPR inference failed", ex);
+            throw new ResponseStatusException(BAD_REQUEST, ex.getMessage(), ex);
+        }
+    }
+
+    private List<AnprPlateResponse> mapPlates(AnprServiceResult result) {
+        return result.plates().stream()
+                .map(this::toPlateResponse)
+                .collect(Collectors.toList());
+    }
+
+    private AnprPlateResponse toPlateResponse(PlateReading reading) {
+        List<Integer> bbox = List.of(
+                reading.boundingBox().x(),
+                reading.boundingBox().y(),
+                reading.boundingBox().width(),
+                reading.boundingBox().height());
+        return new AnprPlateResponse(bbox, reading.text(), reading.confidence());
+    }
+
+    private BufferedImage readImageFromMultipart(MultipartFile image) {
+        if (image == null || image.isEmpty()) {
+            throw new ResponseStatusException(BAD_REQUEST, "Image file is required");
+        }
+        try (var inputStream = image.getInputStream()) {
+            BufferedImage bufferedImage = ImageIO.read(inputStream);
+            if (bufferedImage == null) {
+                throw new ResponseStatusException(BAD_REQUEST, "Unable to decode provided image");
+            }
+            return bufferedImage;
+        } catch (IOException ex) {
+            throw new ResponseStatusException(BAD_REQUEST, "Failed to read uploaded image", ex);
+        }
+    }
+
+    private BufferedImage readImageFromBase64(String encodedImage) {
+        if (!StringUtils.hasText(encodedImage)) {
+            throw new ResponseStatusException(BAD_REQUEST, "Base64 image data is required");
+        }
+        byte[] data;
+        try {
+            data = Base64.getDecoder().decode(encodedImage);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(BAD_REQUEST, "Invalid Base64 image data", ex);
+        }
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(data)) {
+            BufferedImage bufferedImage = ImageIO.read(inputStream);
+            if (bufferedImage == null) {
+                throw new ResponseStatusException(BAD_REQUEST, "Unable to decode Base64 image data");
+            }
+            return bufferedImage;
+        } catch (IOException ex) {
+            throw new ResponseStatusException(BAD_REQUEST, "Failed to read Base64 image data", ex);
+        }
+    }
+}

--- a/src/main/java/com/example/uaecarpalletreader/model/anpr/AnprHealthResponse.java
+++ b/src/main/java/com/example/uaecarpalletreader/model/anpr/AnprHealthResponse.java
@@ -1,0 +1,4 @@
+package com.example.uaecarpalletreader.model.anpr;
+
+public record AnprHealthResponse(boolean enabled, String modelPath) {
+}

--- a/src/main/java/com/example/uaecarpalletreader/model/anpr/AnprInferenceResponse.java
+++ b/src/main/java/com/example/uaecarpalletreader/model/anpr/AnprInferenceResponse.java
@@ -1,0 +1,6 @@
+package com.example.uaecarpalletreader.model.anpr;
+
+import java.util.List;
+
+public record AnprInferenceResponse(List<AnprPlateResponse> plates, long modelTimeMs, long ocrTimeMs) {
+}

--- a/src/main/java/com/example/uaecarpalletreader/model/anpr/AnprPlateResponse.java
+++ b/src/main/java/com/example/uaecarpalletreader/model/anpr/AnprPlateResponse.java
@@ -1,0 +1,6 @@
+package com.example.uaecarpalletreader.model.anpr;
+
+import java.util.List;
+
+public record AnprPlateResponse(List<Integer> bbox, String text, double confidence) {
+}

--- a/src/main/java/com/example/uaecarpalletreader/model/anpr/AnprServiceResult.java
+++ b/src/main/java/com/example/uaecarpalletreader/model/anpr/AnprServiceResult.java
@@ -1,0 +1,6 @@
+package com.example.uaecarpalletreader.model.anpr;
+
+import java.util.List;
+
+public record AnprServiceResult(List<PlateReading> plates, long modelTimeMs, long ocrTimeMs) {
+}

--- a/src/main/java/com/example/uaecarpalletreader/model/anpr/Base64ImageRequest.java
+++ b/src/main/java/com/example/uaecarpalletreader/model/anpr/Base64ImageRequest.java
@@ -1,0 +1,6 @@
+package com.example.uaecarpalletreader.model.anpr;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record Base64ImageRequest(@NotBlank String image) {
+}

--- a/src/main/java/com/example/uaecarpalletreader/model/anpr/PlateReading.java
+++ b/src/main/java/com/example/uaecarpalletreader/model/anpr/PlateReading.java
@@ -1,0 +1,6 @@
+package com.example.uaecarpalletreader.model.anpr;
+
+import com.example.uaecarpalletreader.model.BoundingBox;
+
+public record PlateReading(BoundingBox boundingBox, String text, double confidence) {
+}

--- a/src/main/java/com/example/uaecarpalletreader/service/anpr/AnprService.java
+++ b/src/main/java/com/example/uaecarpalletreader/service/anpr/AnprService.java
@@ -1,0 +1,51 @@
+package com.example.uaecarpalletreader.service.anpr;
+
+import com.example.uaecarpalletreader.config.AnprProperties;
+import com.example.uaecarpalletreader.model.anpr.AnprServiceResult;
+import com.example.uaecarpalletreader.model.anpr.PlateReading;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.awt.image.BufferedImage;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class AnprService {
+
+    private static final Logger log = LoggerFactory.getLogger(AnprService.class);
+
+    private final AnprProperties properties;
+    private final OpenCvYoloDetector detector;
+    private final TesseractOcrEngine ocrEngine;
+
+    public AnprService(AnprProperties properties, OpenCvYoloDetector detector, TesseractOcrEngine ocrEngine) {
+        this.properties = properties;
+        this.detector = detector;
+        this.ocrEngine = ocrEngine;
+    }
+
+    public AnprServiceResult detectAndRead(BufferedImage image) {
+        if (!properties.isEnabled()) {
+            throw new IllegalStateException("ANPR service is disabled via configuration");
+        }
+        long modelStart = System.nanoTime();
+        List<PlateCandidate> detections = detector.detect(image);
+        long modelElapsed = System.nanoTime() - modelStart;
+
+        long ocrStart = System.nanoTime();
+        List<PlateReading> readings = new ArrayList<>(detections.size());
+        for (PlateCandidate candidate : detections) {
+            String text = ocrEngine.read(candidate.roi());
+            readings.add(new PlateReading(candidate.boundingBox(), text, candidate.confidence()));
+        }
+        long ocrElapsed = System.nanoTime() - ocrStart;
+
+        long modelTimeMs = Duration.ofNanos(modelElapsed).toMillis();
+        long ocrTimeMs = Duration.ofNanos(ocrElapsed).toMillis();
+        log.debug("ANPR detection produced {} candidates in {} ms (OCR {} ms)", readings.size(), modelTimeMs, ocrTimeMs);
+        return new AnprServiceResult(readings, modelTimeMs, ocrTimeMs);
+    }
+}

--- a/src/main/java/com/example/uaecarpalletreader/service/anpr/OpenCvYoloDetector.java
+++ b/src/main/java/com/example/uaecarpalletreader/service/anpr/OpenCvYoloDetector.java
@@ -1,0 +1,245 @@
+package com.example.uaecarpalletreader.service.anpr;
+
+import com.example.uaecarpalletreader.config.AnprProperties;
+import com.example.uaecarpalletreader.model.BoundingBox;
+import nu.pattern.OpenCV;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.MatOfByte;
+import org.opencv.core.Point;
+import org.opencv.core.Rect;
+import org.opencv.core.Scalar;
+import org.opencv.core.Size;
+import org.opencv.dnn.Dnn;
+import org.opencv.dnn.Net;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.imageio.ImageIO;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferByte;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+@Component
+public class OpenCvYoloDetector {
+
+    private static final Logger log = LoggerFactory.getLogger(OpenCvYoloDetector.class);
+
+    static {
+        OpenCV.loadLocally();
+        log.info("Loaded OpenCV native libraries");
+    }
+
+    private final AnprProperties properties;
+    private volatile Net network;
+    private final Object networkLock = new Object();
+
+    public OpenCvYoloDetector(AnprProperties properties) {
+        this.properties = properties;
+    }
+
+    public List<PlateCandidate> detect(BufferedImage image) {
+        Objects.requireNonNull(image, "BufferedImage must not be null");
+        Net net = ensureNetwork();
+        Mat source = bufferedImageToMat(image);
+        Size inputSize = new Size(properties.getInputSize(), properties.getInputSize());
+        Mat blob = Dnn.blobFromImage(source, 1.0 / 255.0, inputSize, new Scalar(0, 0, 0), true, false);
+        net.setInput(blob);
+        Mat rawResult = net.forward();
+        Mat reshaped = rawResult.reshape(1, (int) rawResult.size(2));
+        float[] data = new float[(int) (reshaped.total() * reshaped.channels())];
+        reshaped.get(0, 0, data);
+
+        int imageWidth = image.getWidth();
+        int imageHeight = image.getHeight();
+        float xFactor = imageWidth / (float) properties.getInputSize();
+        float yFactor = imageHeight / (float) properties.getInputSize();
+        int channels = reshaped.cols();
+
+        List<Detection> detections = new ArrayList<>();
+        for (int i = 0; i < reshaped.rows(); i++) {
+            int offset = i * channels;
+            float cx = data[offset];
+            float cy = data[offset + 1];
+            float w = data[offset + 2];
+            float h = data[offset + 3];
+            float objectness = data[offset + 4];
+            float confidence = objectness;
+            int classCount = channels - 5;
+            float maxClassScore = 0f;
+            for (int c = 0; c < classCount; c++) {
+                float classScore = data[offset + 5 + c];
+                if (classScore > maxClassScore) {
+                    maxClassScore = classScore;
+                }
+            }
+            if (classCount > 0) {
+                confidence *= maxClassScore;
+            }
+            if (confidence < properties.getConfThreshold()) {
+                continue;
+            }
+
+            int left = Math.round((cx - w / 2f) * xFactor);
+            int top = Math.round((cy - h / 2f) * yFactor);
+            int width = Math.round(w * xFactor);
+            int height = Math.round(h * yFactor);
+
+            left = clamp(left, 0, imageWidth - 1);
+            top = clamp(top, 0, imageHeight - 1);
+            width = clamp(width, 1, imageWidth - left);
+            height = clamp(height, 1, imageHeight - top);
+
+            Rect rect = new Rect(new Point(left, top), new Point(left + width, top + height));
+            detections.add(new Detection(rect, confidence));
+        }
+
+        List<Detection> filtered = applyNms(detections, properties.getNmsThreshold());
+        List<PlateCandidate> candidates = new ArrayList<>(filtered.size());
+        for (Detection detection : filtered) {
+            Rect rect = detection.box();
+            Mat roi = new Mat(source, rect).clone();
+            try {
+                BufferedImage roiImage = matToBufferedImage(roi);
+                BoundingBox boundingBox = new BoundingBox(rect.x, rect.y, rect.width, rect.height);
+                candidates.add(new PlateCandidate(boundingBox, roiImage, detection.confidence()));
+            } finally {
+                roi.release();
+            }
+        }
+
+        blob.release();
+        reshaped.release();
+        rawResult.release();
+        source.release();
+        return candidates;
+    }
+
+    private Net ensureNetwork() {
+        Net current = network;
+        if (current != null) {
+            return current;
+        }
+        synchronized (networkLock) {
+            if (network == null) {
+                String modelPath = properties.getModelPath();
+                if (modelPath == null || modelPath.isBlank()) {
+                    throw new IllegalStateException("Model path must be configured");
+                }
+                Path path = Path.of(modelPath);
+                if (!Files.exists(path)) {
+                    log.warn("YOLO model file {} not found. Detection requests will fail until the model is available.", modelPath);
+                } else {
+                    log.info("Loading YOLO model from {}", path.toAbsolutePath());
+                }
+                network = Dnn.readNetFromONNX(modelPath);
+            }
+            return network;
+        }
+    }
+
+    private Mat bufferedImageToMat(BufferedImage image) {
+        BufferedImage converted = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_3BYTE_BGR);
+        Graphics2D graphics = converted.createGraphics();
+        try {
+            graphics.drawImage(image, 0, 0, null);
+        } finally {
+            graphics.dispose();
+        }
+        byte[] data = ((DataBufferByte) converted.getRaster().getDataBuffer()).getData();
+        Mat mat = new Mat(image.getHeight(), image.getWidth(), CvType.CV_8UC3);
+        mat.put(0, 0, data);
+        return mat;
+    }
+
+    private BufferedImage matToBufferedImage(Mat mat) {
+        MatOfByte buffer = new MatOfByte();
+        try {
+            if (!ImageIO.getImageWritersByFormatName("png").hasNext()) {
+                throw new IllegalStateException("PNG ImageWriter not available");
+            }
+            boolean encoded = org.opencv.imgcodecs.Imgcodecs.imencode(".png", mat, buffer);
+            if (!encoded) {
+                throw new IllegalStateException("Failed to encode ROI to PNG");
+            }
+            try (ByteArrayInputStream input = new ByteArrayInputStream(buffer.toArray())) {
+                BufferedImage image = ImageIO.read(input);
+                if (image == null) {
+                    throw new IllegalStateException("Unable to decode ROI image");
+                }
+                return image;
+            }
+        } catch (IOException ex) {
+            throw new IllegalStateException("Unable to convert ROI to BufferedImage", ex);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    private List<Detection> applyNms(List<Detection> detections, double threshold) {
+        if (detections.isEmpty()) {
+            return List.of();
+        }
+        List<Integer> order = new ArrayList<>(detections.size());
+        for (int i = 0; i < detections.size(); i++) {
+            order.add(i);
+        }
+        order.sort(Comparator.comparingDouble((Integer idx) -> detections.get(idx).confidence()).reversed());
+        List<Detection> kept = new ArrayList<>();
+        boolean[] suppressed = new boolean[detections.size()];
+        for (int idx : order) {
+            if (suppressed[idx]) {
+                continue;
+            }
+            Detection current = detections.get(idx);
+            kept.add(current);
+            for (int j = 0; j < detections.size(); j++) {
+                if (suppressed[j] || j == idx) {
+                    continue;
+                }
+                double iou = intersectionOverUnion(current.box(), detections.get(j).box());
+                if (iou > threshold) {
+                    suppressed[j] = true;
+                }
+            }
+        }
+        return kept;
+    }
+
+    private double intersectionOverUnion(Rect a, Rect b) {
+        int x1 = Math.max(a.x, b.x);
+        int y1 = Math.max(a.y, b.y);
+        int x2 = Math.min(a.x + a.width, b.x + b.width);
+        int y2 = Math.min(a.y + a.height, b.y + b.height);
+        int intersectionArea = Math.max(0, x2 - x1) * Math.max(0, y2 - y1);
+        int areaA = a.width * a.height;
+        int areaB = b.width * b.height;
+        int union = areaA + areaB - intersectionArea;
+        if (union <= 0) {
+            return 0d;
+        }
+        return intersectionArea / (double) union;
+    }
+
+    private int clamp(int value, int min, int max) {
+        if (value < min) {
+            return min;
+        }
+        if (value > max) {
+            return max;
+        }
+        return value;
+    }
+
+    private record Detection(Rect box, double confidence) {
+    }
+}

--- a/src/main/java/com/example/uaecarpalletreader/service/anpr/PlateCandidate.java
+++ b/src/main/java/com/example/uaecarpalletreader/service/anpr/PlateCandidate.java
@@ -1,0 +1,8 @@
+package com.example.uaecarpalletreader.service.anpr;
+
+import com.example.uaecarpalletreader.model.BoundingBox;
+
+import java.awt.image.BufferedImage;
+
+public record PlateCandidate(BoundingBox boundingBox, BufferedImage roi, double confidence) {
+}

--- a/src/main/java/com/example/uaecarpalletreader/service/anpr/TesseractOcrEngine.java
+++ b/src/main/java/com/example/uaecarpalletreader/service/anpr/TesseractOcrEngine.java
@@ -1,0 +1,47 @@
+package com.example.uaecarpalletreader.service.anpr;
+
+import com.example.uaecarpalletreader.config.AnprProperties;
+import net.sourceforge.tess4j.Tesseract;
+import net.sourceforge.tess4j.TesseractException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.awt.image.BufferedImage;
+import java.util.Locale;
+
+@Component
+public class TesseractOcrEngine {
+
+    private static final Logger log = LoggerFactory.getLogger(TesseractOcrEngine.class);
+
+    private final Tesseract tesseract;
+
+    public TesseractOcrEngine(AnprProperties properties) {
+        this.tesseract = new Tesseract();
+        String tessdataPath = properties.getTessdataPath();
+        if (tessdataPath != null && !tessdataPath.isBlank()) {
+            log.info("Configuring Tesseract data path: {}", tessdataPath);
+            tesseract.setDatapath(tessdataPath);
+        }
+        String languages = properties.getLanguages();
+        if (languages == null || languages.isBlank()) {
+            languages = "ara+eng";
+        }
+        tesseract.setLanguage(languages);
+    }
+
+    public String read(BufferedImage roi) {
+        try {
+            String raw = tesseract.doOCR(roi);
+            if (raw == null) {
+                return "";
+            }
+            return raw.replaceAll("\\s+", " ").trim();
+        } catch (TesseractException ex) {
+            String message = String.format(Locale.ROOT, "Failed to run OCR on ROI: %s", ex.getMessage());
+            log.error(message, ex);
+            throw new IllegalStateException(message, ex);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,9 +1,0 @@
-server:
-  port: 9090
-spring:
-  application:
-    name: uae-car-pallet-reader
-logging:
-  level:
-    root: INFO
-    com.example.uaecarpalletreader: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+server:
+  port: 9090
+spring:
+  application:
+    name: uae-car-pallet-reader
+logging:
+  level:
+    root: INFO
+    com.example.uaecarpalletreader: DEBUG
+anpr:
+  enabled: true
+  modelPath: ./models/yolov8n_plate.onnx
+  inputSize: 640
+  confThreshold: 0.25
+  nmsThreshold: 0.45
+  tessdataPath: "C:/Program Files/Tesseract-OCR/tessdata"
+  languages: "ara+eng"

--- a/src/test/java/com/example/uaecarpalletreader/controller/AnprControllerTest.java
+++ b/src/test/java/com/example/uaecarpalletreader/controller/AnprControllerTest.java
@@ -1,0 +1,72 @@
+package com.example.uaecarpalletreader.controller;
+
+import com.example.uaecarpalletreader.model.BoundingBox;
+import com.example.uaecarpalletreader.model.anpr.AnprServiceResult;
+import com.example.uaecarpalletreader.model.anpr.PlateReading;
+import com.example.uaecarpalletreader.service.anpr.AnprService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AnprControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AnprService anprService;
+
+    @Test
+    void inferReturnsAtLeastOnePlate() throws Exception {
+        when(anprService.detectAndRead(any(BufferedImage.class)))
+                .thenReturn(new AnprServiceResult(
+                        List.of(new PlateReading(new BoundingBox(10, 20, 100, 40), "A 12345", 0.95)),
+                        23,
+                        15));
+
+        BufferedImage plateImage = new BufferedImage(200, 100, BufferedImage.TYPE_3BYTE_BGR);
+        Graphics2D graphics = plateImage.createGraphics();
+        try {
+            graphics.setColor(Color.WHITE);
+            graphics.fillRect(0, 0, 200, 100);
+            graphics.setColor(Color.BLACK);
+            graphics.drawString("A 12345", 50, 50);
+        } finally {
+            graphics.dispose();
+        }
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ImageIO.write(plateImage, "png", outputStream);
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "image",
+                "plate.png",
+                MediaType.IMAGE_PNG_VALUE,
+                outputStream.toByteArray());
+
+        mockMvc.perform(multipart("/api/anpr/infer").file(mockFile))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.plates").isArray())
+                .andExpect(jsonPath("$.plates.length()", greaterThanOrEqualTo(1)));
+    }
+}


### PR DESCRIPTION
## Summary
- add configuration properties and dependencies to load an OpenCV YOLO detector and Tess4J OCR engine for ANPR
- expose `/api/anpr/infer` and `/api/anpr/health` endpoints that return detected plate bounding boxes, OCR text, and timing metadata
- add an ANPR controller test that stubs the service and ensures inference responses include at least one plate result

## Testing
- `mvn -q test` *(fails: unable to download dependencies from Maven Central - HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc91d3ec083328a8ce70ce2b13a37