### PR TITLE
Update OpenCV dependency to available version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,12 @@
         <dependency>
             <groupId>org.openpnp</groupId>
             <artifactId>opencv</artifactId>
-            <version>4.7.0-0</version>
+            <version>4.5.3-0</version>
         </dependency>
         <dependency>
             <groupId>nu.pattern</groupId>
             <artifactId>opencv</artifactId>
-            <version>4.7.0-0</version>
+            <version>4.5.3-0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- downgrade the org.openpnp and nu.pattern OpenCV artifacts to version 4.5.3-0 so Maven can resolve them

## Testing
- not run (network access to Maven Central is blocked in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfcd0e6ae883329b26019d13989c37