### PR TITLE
Add OpenPnP repository for OpenCV artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,4 +93,15 @@
             </plugin>
         </plugins>
     </build>
+
+    <repositories>
+        <repository>
+            <id>openpnp-maven-repo</id>
+            <name>OpenPnP Maven Repository</name>
+            <url>https://raw.githubusercontent.com/openpnp/maven-repo/master</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
## Summary
- add the OpenPnP Maven repository so the org.openpnp and nu.pattern OpenCV artifacts can be resolved

## Testing
- mvn -q test *(fails: could not download dependencies due to HTTP 403 from Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfceb20cd8833290314e416611ff65