### PR TITLE
Ensure training script uses bundled dataset configuration

### DIFF
--- a/uae-anpr/training/train_yolo.py
+++ b/uae-anpr/training/train_yolo.py
@@ -18,7 +18,13 @@ def parse_args() -> argparse.Namespace:
         default="yolo11n.pt",
         help="Pretrained weights to start from",
     )
-    parser.add_argument("--data", type=str, default="data.yaml", help="Dataset YAML path")
+    default_data = Path(__file__).with_name("data.yaml").resolve()
+    parser.add_argument(
+        "--data",
+        type=str,
+        default=str(default_data),
+        help="Dataset YAML path",
+    )
     return parser.parse_args()
 
 


### PR DESCRIPTION
## Summary
- resolve the default data.yaml path relative to the training script so Ultralytics does not look in the global dataset directory

## Testing
- python -m training.train_yolo --help *(fails: ModuleNotFoundError: No module named 'ultralytics')*

------
https://chatgpt.com/codex/tasks/task_e_68e1113a6bf883329467b74d77fd6b9f