### PR TITLE
Improve auto-label model dependency guidance

### DIFF
--- a/uae-anpr/README.md
+++ b/uae-anpr/README.md
@@ -14,7 +14,7 @@ uae-anpr/
 
 Place your raw plate images inside `training/data/images`. The `utils_autosplit.py` helper will move them into `train/` and `val/` splits (85/15) the first time you run it. Labels should be supplied in YOLO format under `training/data/labels/train` and `training/data/labels/val`.
 
-If you need to bootstrap annotations, the repository ships with `training/auto_label.py`, which wraps a pre-trained licence plate detector (`keremberke/yolov8n-license-plate`). Once your images have been split, run:
+If you need to bootstrap annotations, the repository ships with `training/auto_label.py`, which wraps a pre-trained licence plate detector (`keremberke/yolov8n-license-plate`). The script relies on the [`huggingface-hub`](https://pypi.org/project/huggingface-hub/) package to download the checkpoint the first time it runs. Once your images have been split, run:
 
 ```bash
 cd training

--- a/uae-anpr/training/auto_label.py
+++ b/uae-anpr/training/auto_label.py
@@ -16,6 +16,27 @@ except ImportError:  # pragma: no cover - OpenCV should be available via require
 from ultralytics import YOLO
 
 
+def ensure_huggingface_available(model_name: str) -> None:
+    """Raise a helpful error when a Hugging Face model cannot be resolved."""
+
+    if "/" not in model_name:
+        return
+
+    candidate = Path(model_name)
+    if candidate.exists():
+        return
+
+    try:
+        import huggingface_hub  # type: ignore # noqa: F401
+    except ImportError as exc:  # pragma: no cover - only triggered on misconfiguration
+        raise RuntimeError(
+            "The requested model appears to be hosted on the Hugging Face Hub but the "
+            "'huggingface-hub' package is not installed. Install it with "
+            "`pip install huggingface-hub` or add it to your environment before "
+            "running auto_label.py."
+        ) from exc
+
+
 SUPPORTED_SUFFIXES = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
 
 
@@ -253,6 +274,7 @@ def run_detector(
     gamma_value: float,
     sharpen_strength: float,
 ) -> List[Tuple[ImageLabelPair, List[Tuple[int, float, float, float, float]]]]:
+    ensure_huggingface_available(model_name)
     model = YOLO(model_name)
 
     if enhancements:

--- a/uae-anpr/training/requirements.txt
+++ b/uae-anpr/training/requirements.txt
@@ -1,3 +1,4 @@
 ultralytics==8.3.10
 opencv-python
 numpy
+huggingface-hub>=0.24.0


### PR DESCRIPTION
## Summary
- add a guard that surfaces a clear error when the Hugging Face dependency for the auto-labelling model is missing
- declare the huggingface-hub package in the training requirements and document the need for it in the README

## Testing
- python -m compileall training/auto_label.py

------
https://chatgpt.com/codex/tasks/task_e_68e11c7c1cdc8332a53a356e0c30862b