### PR TITLE
Add Swagger UI and enhance UAE plate recognition heuristics

### DIFF
--- a/uae-anpr/README.md
+++ b/uae-anpr/README.md
@@ -15,6 +15,7 @@ java -jar target/uae-ocr-anpr-0.0.1-SNAPSHOT.jar
 ```bash
 curl -X POST http://localhost:9090/api/v1/plates/recognize   -F "image=@/path/to/plate.jpg"
 ```
+5. Explore and test with the interactive Swagger UI at [http://localhost:9090/swagger-ui/index.html](http://localhost:9090/swagger-ui/index.html).
 
 ## API
 - `POST /api/v1/plates/recognize` (multipart)
@@ -26,6 +27,11 @@ curl -X POST http://localhost:9090/api/v1/plates/recognize   -F "image=@/path/to
   ]
 }
 ```
+
+## Features
+- Automatic OpenAPI/Swagger documentation with a ready to use UI.
+- Improved plate detection heuristics that work on cropped plates and wider vehicle photos.
+- Dynamic splitting of letter/digit regions to better support different emirate layouts.
 
 ## Notes
 - The service attempts to auto-detect a likely plate rectangle via contour heuristics. If none is found, it OCRs the whole image as a fallback.

--- a/uae-anpr/pom.xml
+++ b/uae-anpr/pom.xml
@@ -31,6 +31,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <version>2.5.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.bytedeco</groupId>
       <artifactId>opencv-platform</artifactId>
       <version>4.9.0-1.5.10</version>

--- a/uae-anpr/src/main/java/com/example/anpr/config/OpenApiConfig.java
+++ b/uae-anpr/src/main/java/com/example/anpr/config/OpenApiConfig.java
@@ -1,0 +1,23 @@
+package com.example.anpr.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI plateRecognitionApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("UAE License Plate Recognition API")
+                        .description("REST API that extracts the emirate, letter and number from UAE license plate images.")
+                        .version("1.0.0")
+                        .contact(new Contact()
+                                .name("UAE OCR ANPR")
+                                .url("https://github.com/")));
+    }
+}

--- a/uae-anpr/src/main/java/com/example/anpr/dto/PlateResponse.java
+++ b/uae-anpr/src/main/java/com/example/anpr/dto/PlateResponse.java
@@ -1,7 +1,14 @@
 package com.example.anpr.dto;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
-public record PlateResponse(java.util.List<PlateResult> results) {
-    public static PlateResponse of(PlateResult r) { return new PlateResponse(java.util.List.of(r)); }
+@Schema(description = "Response returned by the plate recognition endpoint")
+public record PlateResponse(
+        @ArraySchema(arraySchema = @Schema(description = "Recognized plate candidates"),
+                schema = @Schema(implementation = PlateResult.class))
+        List<PlateResult> results) {
+    public static PlateResponse of(PlateResult r) { return new PlateResponse(List.of(r)); }
 }

--- a/uae-anpr/src/main/java/com/example/anpr/dto/PlateResult.java
+++ b/uae-anpr/src/main/java/com/example/anpr/dto/PlateResult.java
@@ -1,3 +1,11 @@
 package com.example.anpr.dto;
 
-public record PlateResult(String number, String letter, String emirate, String rawText) {}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Structured information extracted from a UAE license plate")
+public record PlateResult(
+        @Schema(description = "Normalized numeric portion of the plate", example = "97344") String number,
+        @Schema(description = "Latin letter encoded on the plate", example = "F") String letter,
+        @Schema(description = "Matched emirate name", example = "Dubai") String emirate,
+        @Schema(description = "Raw OCR text used for debugging", example = "EMIRATE_RAW=Dubai | DIGITS_RAW=97344 | LETTERS_TRIED=F")
+        String rawText) {}

--- a/uae-anpr/src/main/java/com/example/anpr/service/PlateService.java
+++ b/uae-anpr/src/main/java/com/example/anpr/service/PlateService.java
@@ -4,13 +4,18 @@ import com.example.anpr.dto.PlateResponse;
 import com.example.anpr.dto.PlateResult;
 import com.example.anpr.util.EmirateParser;
 import com.example.anpr.util.ImageUtils;
+import org.bytedeco.javacpp.indexer.UByteRawIndexer;
 import org.bytedeco.opencv.opencv_core.Mat;
 import org.bytedeco.opencv.opencv_core.Rect;
 import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.global.opencv_imgproc;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 @Service
 public class PlateService {
@@ -24,13 +29,38 @@ public class PlateService {
     public PlateResponse recognize(byte[] imageBytes) {
         Mat src = ImageUtils.readMat(imageBytes);
 
-        Rect roi = ImageUtils.tryFindPlateROI(src);
-        Mat plate = (roi != null) ? new Mat(src, roi).clone() : src;
+        PlateResult best = recognizeFrom(src, true, "ORIGINAL");
+        best = better(best, recognizeFrom(src, false, "ORIGINAL"));
 
-        plate = ImageUtils.resize(plate, 2.0);
+        if (confidence(best) < 4 && Math.max(src.cols(), src.rows()) < 1200) {
+            PlateResult scaled = recognizeFrom(ImageUtils.resize(src, 1.5), true, "UPSCALED");
+            best = better(best, scaled);
+        }
 
-        int W = plate.cols(), H = plate.rows();
-        int leftW = Math.max(30, (int)(W * 0.32));
+        return PlateResponse.of(best);
+    }
+
+    private PlateResult recognizeFrom(Mat src, boolean tryRoi, String stageLabel) {
+        Rect roi = tryRoi ? ImageUtils.tryFindPlateROI(src) : null;
+        Mat plate = (roi != null) ? new Mat(src, roi).clone() : src.clone();
+        Mat normalized = ImageUtils.ensureHeight(plate, 240, 720);
+        String stage = stageLabel + (roi != null ? "_CROP" : "_FULL");
+        return analyzePlate(normalized, roi, stage);
+    }
+
+    private PlateResult analyzePlate(Mat plate, Rect roi, String stage) {
+        Mat plateGray = ImageUtils.toGray(plate);
+        int W = plate.cols();
+        int H = plate.rows();
+
+        int estimatedSplit = estimateLeftBandWidth(plateGray);
+        int minLeft = Math.max(20, (int) (W * 0.18));
+        int maxLeft = Math.max(minLeft + 1, W - 40);
+        int leftW = Math.max(minLeft, Math.min(estimatedSplit, maxLeft));
+        if (W - leftW < 40) {
+            leftW = Math.max(1, W - 40);
+        }
+        leftW = Math.min(leftW, W - 1);
         Rect leftRect = new Rect(0, 0, leftW, H);
         Rect rightRect = new Rect(leftW, 0, W - leftW, H);
 
@@ -41,16 +71,23 @@ public class PlateService {
         Mat leftBin = ImageUtils.adaptive(leftGray);
         Mat leftInv = new Mat();
         opencv_core.bitwise_not(leftBin, leftInv);
+        Mat kernel = opencv_imgproc.getStructuringElement(opencv_imgproc.MORPH_RECT,
+                new org.bytedeco.opencv.opencv_core.Size(2, 2));
         Mat leftThick = new Mat();
-        Mat kernel = opencv_imgproc.getStructuringElement(opencv_imgproc.MORPH_RECT, new org.bytedeco.opencv.opencv_core.Size(2,2));
         opencv_imgproc.dilate(leftBin, leftThick, kernel);
         Mat leftThin = new Mat();
         opencv_imgproc.erode(leftBin, leftThin, kernel);
 
         Mat rightGray = ImageUtils.toGray(right);
         Mat rightBin = ImageUtils.enhanceForOCR(rightGray);
+        Mat rightClose = new Mat();
+        opencv_imgproc.morphologyEx(rightBin, rightClose, opencv_imgproc.MORPH_CLOSE,
+                opencv_imgproc.getStructuringElement(opencv_imgproc.MORPH_RECT,
+                        new org.bytedeco.opencv.opencv_core.Size(3, 3)));
 
-        String digitsRaw  = ocr.ocrDigits(ImageUtils.toBufferedImage(rightBin));
+        String digitsA = ocr.ocrDigits(ImageUtils.toBufferedImage(rightBin));
+        String digitsB = ocr.ocrDigits(ImageUtils.toBufferedImage(rightClose));
+        String digitsRaw = bestDigits(digitsA, digitsB);
 
         String emirA = ocr.ocrEmirate(ImageUtils.toBufferedImage(leftBin));
         String emirB = ocr.ocrEmirate(ImageUtils.toBufferedImage(leftInv));
@@ -68,17 +105,108 @@ public class PlateService {
             String t = (emirateRaw + " " + digitsRaw).toUpperCase();
             if (t.contains("DUBAI") || t.contains("دبي")) parsed.emirate = "Dubai";
             if (t.contains("ABU DHABI") || t.contains("ابوظبي") || t.contains("أبوظبي")) parsed.emirate = "Abu Dhabi";
+            if (t.contains("SHARJAH") || t.contains("الشارقة")) parsed.emirate = "Sharjah";
+            if (t.contains("AJMAN") || t.contains("عجمان")) parsed.emirate = "Ajman";
         }
 
         String number = digitsRaw.replaceAll("\\D+", "");
         parsed.number = number.isBlank() ? parsed.number : number;
         parsed.letter = (letter == null || letter.isBlank()) ? parsed.letter : letter;
 
-        PlateResult one = new PlateResult(parsed.number, parsed.letter, parsed.emirate,
-                "EMIRATE_RAW=" + emirateRaw.replace('\n',' ').trim()
+        String diagnostics = "STAGE=" + stage
+                + (roi != null ? " ROI=" + roi.width() + "x" + roi.height() : " ROI=NONE")
+                + " | CUT=" + leftW + "/" + W
+                + " | EMIRATE_RAW=" + emirateRaw.replace('\n', ' ').trim()
                 + " | DIGITS_RAW=" + digitsRaw.trim()
-                + " | LETTERS_TRIED=" + String.join(",", Arrays.asList(L1,L2,L3,L4)));
-        return PlateResponse.of(one);
+                + " | LETTERS_TRIED=" + String.join(",", Arrays.asList(L1, L2, L3, L4));
+
+        return new PlateResult(parsed.number, parsed.letter, parsed.emirate, diagnostics);
+    }
+
+    private static int estimateLeftBandWidth(Mat plateGray) {
+        Mat blur = new Mat();
+        opencv_imgproc.GaussianBlur(plateGray, blur,
+                new org.bytedeco.opencv.opencv_core.Size(3, 3), 0);
+        Mat gradX = new Mat();
+        opencv_imgproc.Sobel(blur, gradX, opencv_core.CV_16S, 1, 0, 3, 1, 0, opencv_core.BORDER_DEFAULT);
+        Mat absGrad = new Mat();
+        opencv_core.convertScaleAbs(gradX, absGrad);
+
+        int width = absGrad.cols();
+        int height = absGrad.rows();
+        int min = Math.max(10, (int) (width * 0.18));
+        int max = Math.min(width - 10, (int) (width * 0.65));
+        if (max <= min) {
+            return Math.max(10, Math.min((int) (width * 0.32), width - 10));
+        }
+
+        int best = (int) (width * 0.32);
+        double bestScore = -1;
+        try (UByteRawIndexer indexer = absGrad.createIndexer()) {
+            for (int x = min; x < max; x++) {
+                double score = 0;
+                for (int dx = -1; dx <= 1; dx++) {
+                    int col = Math.max(min, Math.min(max - 1, x + dx));
+                    for (int y = 0; y < height; y++) {
+                        score += indexer.get(y, col) & 0xFF;
+                    }
+                }
+                if (score > bestScore) {
+                    bestScore = score;
+                    best = x;
+                }
+            }
+        }
+        int defaultCut = Math.max(10, Math.min((int) (width * 0.32), width - 10));
+        int candidate = Math.max(10, Math.min(best, width - 10));
+        if (candidate <= 10 || candidate >= width - 10) {
+            candidate = defaultCut;
+        }
+        return Math.max(10, Math.min(candidate, width - 10));
+    }
+
+    private PlateResult better(PlateResult current, PlateResult candidate) {
+        if (confidence(candidate) > confidence(current)) {
+            return candidate;
+        }
+        if (confidence(candidate) == confidence(current)
+                && digitScore(candidate != null ? candidate.number() : "")
+                > digitScore(current != null ? current.number() : "")) {
+            return candidate;
+        }
+        return current;
+    }
+
+    private static int confidence(PlateResult result) {
+        if (result == null) {
+            return -1;
+        }
+        int score = 0;
+        if (result.number() != null && !result.number().isBlank()) {
+            score += Math.min(5, result.number().replaceAll("\\D+", "").length());
+        }
+        if (result.letter() != null && !result.letter().isBlank()) {
+            score += 2;
+        }
+        if (result.emirate() != null && !result.emirate().isBlank()
+                && !"Unknown".equalsIgnoreCase(result.emirate())) {
+            score += 2;
+        }
+        return score;
+    }
+
+    private static String bestDigits(String... options) {
+        return Arrays.stream(options)
+                .filter(Objects::nonNull)
+                .max(Comparator.comparingInt(PlateService::digitScore))
+                .orElse("");
+    }
+
+    private static int digitScore(String value) {
+        if (value == null) {
+            return -1;
+        }
+        return value.replaceAll("\\D+", "").length();
     }
 
     private static String normalizeLetter(String s) {

--- a/uae-anpr/src/main/java/com/example/anpr/util/ImageUtils.java
+++ b/uae-anpr/src/main/java/com/example/anpr/util/ImageUtils.java
@@ -21,6 +21,20 @@ public class ImageUtils {
         );
         return out;
     }
+
+    public static Mat ensureHeight(Mat mat, int minHeight, int maxHeight) {
+        if (mat.empty()) {
+            return mat.clone();
+        }
+        int h = mat.rows();
+        if (minHeight > 0 && h < minHeight) {
+            return resize(mat, Math.min(4.0, minHeight / (double) h));
+        }
+        if (maxHeight > 0 && h > maxHeight) {
+            return resize(mat, Math.max(0.25, maxHeight / (double) h));
+        }
+        return mat.clone();
+    }
     public static Mat adaptive(Mat gray) {
         Mat th = new Mat();
         org.bytedeco.opencv.global.opencv_imgproc.adaptiveThreshold(
@@ -67,6 +81,18 @@ public class ImageUtils {
 
     /** Try to find a license-plate-like rectangle using contours. */
     public static Rect tryFindPlateROI(Mat srcBgr) {
+        Rect candidate = findPlateByContours(srcBgr);
+        if (candidate != null) {
+            return expandWithin(candidate, srcBgr.size(), 0.08);
+        }
+        candidate = findPlateByGradients(srcBgr);
+        if (candidate != null) {
+            return expandWithin(candidate, srcBgr.size(), 0.10);
+        }
+        return null;
+    }
+
+    private static Rect findPlateByContours(Mat srcBgr) {
         Mat gray = toGray(srcBgr);
         Mat edges = new Mat();
         opencv_imgproc.Canny(gray, edges, 50, 150);
@@ -78,18 +104,91 @@ public class ImageUtils {
         Mat hierarchy = new Mat();
         opencv_imgproc.findContours(edges, contours, hierarchy, opencv_imgproc.RETR_EXTERNAL, opencv_imgproc.CHAIN_APPROX_SIMPLE);
 
+        return selectBestContour(contours, srcBgr.size(), 0.0005, 0.25);
+    }
+
+    private static Rect findPlateByGradients(Mat srcBgr) {
+        Mat gray = toGray(srcBgr);
+        Mat gradX = new Mat();
+        opencv_imgproc.Sobel(gray, gradX, opencv_core.CV_16S, 1, 0, 3, 1, 0, opencv_core.BORDER_DEFAULT);
+        Mat absGradX = new Mat();
+        opencv_core.convertScaleAbs(gradX, absGradX);
+        Mat blur = new Mat();
+        opencv_imgproc.GaussianBlur(absGradX, blur, new Size(5,5), 0);
+        Mat binary = new Mat();
+        opencv_imgproc.threshold(blur, binary, 0, 255, opencv_imgproc.THRESH_BINARY | opencv_imgproc.THRESH_OTSU);
+
+        Mat kernel = opencv_imgproc.getStructuringElement(opencv_imgproc.MORPH_RECT, new Size(17,5));
+        opencv_imgproc.morphologyEx(binary, binary, opencv_imgproc.MORPH_CLOSE, kernel);
+        opencv_imgproc.dilate(binary, binary, kernel);
+
+        MatVector contours = new MatVector();
+        Mat hierarchy = new Mat();
+        opencv_imgproc.findContours(binary, contours, hierarchy, opencv_imgproc.RETR_EXTERNAL, opencv_imgproc.CHAIN_APPROX_SIMPLE);
+
+        Rect candidate = selectBestContour(contours, srcBgr.size(), 0.0003, 0.3);
+        if (candidate != null) {
+            return candidate;
+        }
+
+        MatVector refinedContours = new MatVector();
+        opencv_imgproc.morphologyEx(binary, binary, opencv_imgproc.MORPH_OPEN, kernel);
+        opencv_imgproc.findContours(binary, refinedContours, hierarchy, opencv_imgproc.RETR_EXTERNAL, opencv_imgproc.CHAIN_APPROX_SIMPLE);
+        return selectBestContour(refinedContours, srcBgr.size(), 0.0003, 0.3);
+    }
+
+    private static Rect selectBestContour(MatVector contours, Size bounds, double minAreaRatio, double maxAreaRatio) {
+        if (contours == null || contours.size() == 0) {
+            return null;
+        }
+        double imageArea = Math.max(1.0, bounds.width() * (double) bounds.height());
         double bestScore = 0;
         Rect best = null;
-        for (long i=0; i<contours.size(); i++) {
+        for (long i = 0; i < contours.size(); i++) {
             Mat cnt = contours.get(i);
             Rect r = opencv_imgproc.boundingRect(cnt);
+            if (r.width() <= 0 || r.height() <= 0) {
+                continue;
+            }
             double ar = r.width() / (double) r.height();
+            if (ar < 2.0 || ar > 8.5) {
+                continue;
+            }
             double area = r.width() * (double) r.height();
-            if (ar > 2.5 && ar < 6.5 && area > 2000) {
-                double score = area;
-                if (score > bestScore) { bestScore = score; best = r; }
+            double areaRatio = area / imageArea;
+            if (areaRatio < minAreaRatio || areaRatio > maxAreaRatio) {
+                continue;
+            }
+            double contourArea = Math.max(opencv_imgproc.contourArea(cnt), 1.0);
+            double fillRatio = contourArea / area;
+            if (fillRatio < 0.35) {
+                continue;
+            }
+            double aspectScore = 1.0 - Math.min(Math.abs(ar - 4.5) / 4.5, 0.9);
+            double score = areaRatio * (0.6 + 0.4 * fillRatio) * aspectScore;
+            if (score > bestScore) {
+                bestScore = score;
+                best = r;
             }
         }
         return best;
+    }
+
+    private static Rect expandWithin(Rect rect, Size bounds, double paddingRatio) {
+        if (rect == null) {
+            return null;
+        }
+        int width = bounds.width();
+        int height = bounds.height();
+        int padX = (int) Math.round(rect.width() * paddingRatio);
+        int padY = (int) Math.round(rect.height() * paddingRatio);
+        int x = Math.max(rect.x() - padX, 0);
+        int y = Math.max(rect.y() - padY, 0);
+        int w = Math.min(rect.width() + padX * 2, width - x);
+        int h = Math.min(rect.height() + padY * 2, height - y);
+        if (w <= 0 || h <= 0) {
+            return null;
+        }
+        return new Rect(x, y, w, h);
     }
 }

--- a/uae-anpr/src/main/java/com/example/anpr/web/PlateController.java
+++ b/uae-anpr/src/main/java/com/example/anpr/web/PlateController.java
@@ -2,12 +2,22 @@ package com.example.anpr.web;
 
 import com.example.anpr.dto.PlateResponse;
 import com.example.anpr.service.PlateService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/plates")
+@Tag(name = "Plate recognition")
 public class PlateController {
 
     private final PlateService plateService;
@@ -17,7 +27,20 @@ public class PlateController {
     }
 
     @PostMapping(value = "/recognize", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public PlateResponse recognize(@RequestPart("image") MultipartFile image) throws Exception {
+    @Operation(
+            summary = "Recognize a UAE license plate",
+            description = "Accepts a vehicle or plate image and extracts the emirate, letter and number using OCR.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Plate recognized",
+                            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = PlateResponse.class)))
+            }
+    )
+    public PlateResponse recognize(
+            @Parameter(description = "Vehicle or close-up plate image (PNG or JPEG).", required = true,
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                            schema = @Schema(type = "string", format = "binary")))
+            @RequestPart("image") MultipartFile image) {
         return plateService.recognize(image.getBytes());
     }
 }


### PR DESCRIPTION
## Summary
- add springdoc OpenAPI UI with endpoint and DTO annotations for Swagger documentation
- overhaul the recognition service with stronger ROI detection, dynamic letter/digit splitting, and fallback passes for whole-vehicle photos
- document the Swagger UI entry point and new capabilities in the README

## Testing
- `mvn -q -DskipTests package` *(fails: Maven Central returns HTTP 403 in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e166bbf3a4833287327c12d2be19b1