### PR TITLE
Improve plate letter segmentation heuristics

### DIFF
--- a/uae-anpr/src/main/java/com/example/anpr/util/EmirateParser.java
+++ b/uae-anpr/src/main/java/com/example/anpr/util/EmirateParser.java
@@ -6,19 +6,27 @@ public class EmirateParser {
     private static final Map<String, String> EMIRATES = Map.ofEntries(
             Map.entry("DUBAI", "Dubai"),
             Map.entry("دبي", "Dubai"),
+            Map.entry("DXB", "Dubai"),
             Map.entry("ABU DHABI", "Abu Dhabi"),
+            Map.entry("ABUDHABI", "Abu Dhabi"),
             Map.entry("ابوظبي", "Abu Dhabi"),
             Map.entry("أبوظبي", "Abu Dhabi"),
+            Map.entry("AUH", "Abu Dhabi"),
             Map.entry("SHARJAH", "Sharjah"),
             Map.entry("الشارقة", "Sharjah"),
+            Map.entry("SHJ", "Sharjah"),
             Map.entry("AJMAN", "Ajman"),
             Map.entry("عجمان", "Ajman"),
+            Map.entry("AJMN", "Ajman"),
             Map.entry("RAK", "Ras Al Khaimah"),
             Map.entry("رأس الخيمة", "Ras Al Khaimah"),
             Map.entry("FUJAIRAH", "Fujairah"),
             Map.entry("الفجيرة", "Fujairah"),
+            Map.entry("FJR", "Fujairah"),
             Map.entry("UMM AL QUWAIN", "Umm Al Quwain"),
-            Map.entry("ام القيوين", "Umm Al Quwain")
+            Map.entry("UMM ALQUWAIN", "Umm Al Quwain"),
+            Map.entry("ام القيوين", "Umm Al Quwain"),
+            Map.entry("UAQ", "Umm Al Quwain")
     );
 
     public static class Parsed {


### PR DESCRIPTION
## Summary
- extract and OCR dedicated letter crops from the left band to stabilise character recognition
- expand emirate OCR sampling to include enhanced grayscale variants and consolidate additional aliases
- map more textual variants to emirate names to improve parsing of diverse plate layouts

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download Spring dependencies due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e16cad63c083328610b304973ffe4a