### PR TITLE
Gracefully handle missing tessdata directory

### DIFF
--- a/uae-anpr/README.md
+++ b/uae-anpr/README.md
@@ -5,8 +5,9 @@ No GPU, no deep learning detector.
 
 ## Run (Dev)
 1. Install JDK 21 + Maven.
-2. Download Tesseract languages `eng.traineddata` and `ara.traineddata` and place them under `tessdata/` (or point the
-   `TESSDATA_PREFIX` environment variable at an existing tessdata directory).
+2. (Optional) Download Tesseract languages `eng.traineddata` and `ara.traineddata` and place them under `tessdata/` (or point the
+   `TESSDATA_PREFIX` environment variable at an existing tessdata directory). If omitted, the service falls back to the
+   Tess4J bundled tessdata files.
 3. Build & run:
 ```bash
 mvn -q -DskipTests package


### PR DESCRIPTION
## Summary
- allow OcrService to fall back to Tess4J's embedded tessdata when the configured path is missing
- document the automatic fallback in the README so users are aware of the behavior

## Testing
- `mvn -q -DskipTests package` *(fails: unable to resolve dependencies from Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1babc48a08332aadfc03ae4c95911