### PR TITLE
Replace org.jdesktop layout usage with Swing GroupLayout

### DIFF
--- a/uae-anpr/src/main/java/net/sf/javaanpr/gui/windows/FrameComponentInit.java
+++ b/uae-anpr/src/main/java/net/sf/javaanpr/gui/windows/FrameComponentInit.java
@@ -16,9 +16,8 @@
 
 package net.sf.javaanpr.gui.windows;
 
-import org.jdesktop.layout.GroupLayout;
-
 import javax.swing.*;
+import javax.swing.GroupLayout;
 import javax.swing.border.BevelBorder;
 import java.awt.*;
 
@@ -57,10 +56,10 @@ public class FrameComponentInit extends JFrame {
         label.setBorder(BorderFactory.createBevelBorder(BevelBorder.RAISED));
         GroupLayout layout = new GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
-        layout.setHorizontalGroup(layout.createParallelGroup(GroupLayout.LEADING)
-                .add(label, GroupLayout.DEFAULT_SIZE, 431, Short.MAX_VALUE));
-        layout.setVerticalGroup(layout.createParallelGroup(GroupLayout.LEADING)
-                .add(label, GroupLayout.DEFAULT_SIZE, 50, Short.MAX_VALUE));
+        layout.setHorizontalGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                .addComponent(label, GroupLayout.DEFAULT_SIZE, 431, Short.MAX_VALUE));
+        layout.setVerticalGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                .addComponent(label, GroupLayout.DEFAULT_SIZE, 50, Short.MAX_VALUE));
         pack();
     }
 }

--- a/uae-anpr/src/main/java/net/sf/javaanpr/gui/windows/FrameHelp.java
+++ b/uae-anpr/src/main/java/net/sf/javaanpr/gui/windows/FrameHelp.java
@@ -17,10 +17,10 @@
 package net.sf.javaanpr.gui.windows;
 
 import net.sf.javaanpr.configurator.Configurator;
-import org.jdesktop.layout.GroupLayout;
-import org.jdesktop.layout.LayoutStyle;
 
 import javax.swing.*;
+import javax.swing.GroupLayout;
+import javax.swing.LayoutStyle;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.io.IOException;
@@ -75,16 +75,19 @@ public class FrameHelp extends JFrame {
 
         GroupLayout layout = new GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
-        layout.setHorizontalGroup(layout.createParallelGroup(GroupLayout.LEADING)
-                .add(layout.createSequentialGroup().addContainerGap()
-                        .add(layout.createParallelGroup(GroupLayout.LEADING)
-                                .add(GroupLayout.TRAILING, helpWindowClose)
-                                .add(jScrollPane1, GroupLayout.DEFAULT_SIZE, 514, Short.MAX_VALUE))
+        layout.setHorizontalGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                .addGroup(layout.createSequentialGroup().addContainerGap()
+                        .addGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                                .addComponent(jScrollPane1, GroupLayout.DEFAULT_SIZE, 514, Short.MAX_VALUE)
+                                .addGroup(GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
+                                        .addGap(0, 0, Short.MAX_VALUE)
+                                        .addComponent(helpWindowClose)))
                         .addContainerGap()));
-        layout.setVerticalGroup(layout.createParallelGroup(GroupLayout.LEADING).add(GroupLayout.TRAILING,
-                layout.createSequentialGroup().addContainerGap()
-                        .add(jScrollPane1, GroupLayout.DEFAULT_SIZE, 461, Short.MAX_VALUE)
-                        .addPreferredGap(LayoutStyle.RELATED).add(helpWindowClose).addContainerGap()));
+        layout.setVerticalGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                .addGroup(GroupLayout.Alignment.TRAILING, layout.createSequentialGroup().addContainerGap()
+                        .addComponent(jScrollPane1, GroupLayout.DEFAULT_SIZE, 461, Short.MAX_VALUE)
+                        .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(helpWindowClose).addContainerGap()));
         pack();
     }
 

--- a/uae-anpr/src/main/java/net/sf/javaanpr/gui/windows/FrameMain.java
+++ b/uae-anpr/src/main/java/net/sf/javaanpr/gui/windows/FrameMain.java
@@ -20,10 +20,10 @@ import net.sf.javaanpr.gui.tools.ImageFileFilter;
 import net.sf.javaanpr.imageanalysis.CarSnapshot;
 import net.sf.javaanpr.imageanalysis.Photo;
 import net.sf.javaanpr.jar.Main;
-import org.jdesktop.layout.GroupLayout;
-import org.jdesktop.layout.LayoutStyle;
 
 import javax.swing.*;
+import javax.swing.GroupLayout;
+import javax.swing.LayoutStyle;
 import javax.swing.event.ListSelectionEvent;
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -106,9 +106,9 @@ public class FrameMain extends JFrame {
         GroupLayout panelCarLayout = new GroupLayout(panelCar);
         panelCar.setLayout(panelCarLayout);
         panelCarLayout.setHorizontalGroup(
-                panelCarLayout.createParallelGroup(GroupLayout.LEADING).add(0, 585, Short.MAX_VALUE));
-        panelCarLayout
-                .setVerticalGroup(panelCarLayout.createParallelGroup(GroupLayout.LEADING).add(0, 477, Short.MAX_VALUE));
+                panelCarLayout.createParallelGroup(GroupLayout.Alignment.LEADING).addGap(0, 585, Short.MAX_VALUE));
+        panelCarLayout.setVerticalGroup(
+                panelCarLayout.createParallelGroup(GroupLayout.Alignment.LEADING).addGap(0, 477, Short.MAX_VALUE));
         fileListScrollPane.setBorder(BorderFactory.createEtchedBorder());
         fileListScrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
         fileList.setBackground(UIManager.getDefaults().getColor("Panel.background"));
@@ -145,28 +145,32 @@ public class FrameMain extends JFrame {
         setJMenuBar(menuBar);
         GroupLayout layout = new GroupLayout(getContentPane());
         getContentPane().setLayout(layout); // TODO refactor
-        layout.setHorizontalGroup(layout.createParallelGroup(GroupLayout.LEADING)
-                .add(layout.createSequentialGroup().addContainerGap()
-                        .add(layout.createParallelGroup(GroupLayout.TRAILING)
-                                .add(GroupLayout.LEADING, bottomLine, GroupLayout.DEFAULT_SIZE, 589,
+        layout.setHorizontalGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                .addGroup(layout.createSequentialGroup().addContainerGap()
+                        .addGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                                .addComponent(panelCar, GroupLayout.DEFAULT_SIZE, GroupLayout.DEFAULT_SIZE,
                                         Short.MAX_VALUE)
-                                .add(GroupLayout.LEADING, panelCar, GroupLayout.DEFAULT_SIZE,
-                                        GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)).addPreferredGap(LayoutStyle.RELATED)
-                        .add(layout.createParallelGroup(GroupLayout.TRAILING)
-                                .add(fileListScrollPane, GroupLayout.DEFAULT_SIZE, 190, Short.MAX_VALUE)
-                                .add(GroupLayout.LEADING, recognitionLabel, GroupLayout.DEFAULT_SIZE, 190,
-                                        Short.MAX_VALUE)
-                                .add(recognizeButton, GroupLayout.DEFAULT_SIZE, 190, Short.MAX_VALUE))
+                                .addComponent(bottomLine, GroupLayout.DEFAULT_SIZE, 589, Short.MAX_VALUE))
+                        .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                        .addGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING, false)
+                                .addComponent(fileListScrollPane, GroupLayout.DEFAULT_SIZE, 190, Short.MAX_VALUE)
+                                .addComponent(recognizeButton, GroupLayout.DEFAULT_SIZE, 190, Short.MAX_VALUE)
+                                .addComponent(recognitionLabel, GroupLayout.DEFAULT_SIZE, 190, Short.MAX_VALUE))
                         .addContainerGap()));
-        layout.setVerticalGroup(layout.createParallelGroup(GroupLayout.LEADING)
-                .add(layout.createSequentialGroup().addContainerGap()
-                        .add(layout.createParallelGroup(GroupLayout.LEADING).add(layout.createSequentialGroup()
-                                .add(fileListScrollPane, GroupLayout.DEFAULT_SIZE, 402, Short.MAX_VALUE)
-                                .addPreferredGap(LayoutStyle.RELATED).add(recognizeButton)
-                                .addPreferredGap(LayoutStyle.RELATED)
-                                .add(recognitionLabel, GroupLayout.PREFERRED_SIZE, 44, GroupLayout.PREFERRED_SIZE))
-                                .add(panelCar, GroupLayout.DEFAULT_SIZE, GroupLayout.DEFAULT_SIZE,
-                                        Short.MAX_VALUE)).addPreferredGap(LayoutStyle.RELATED).add(bottomLine)));
+        layout.setVerticalGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                .addGroup(layout.createSequentialGroup().addContainerGap()
+                        .addGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                                .addGroup(layout.createSequentialGroup()
+                                        .addComponent(fileListScrollPane, GroupLayout.DEFAULT_SIZE, 402, Short.MAX_VALUE)
+                                        .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                                        .addComponent(recognizeButton)
+                                        .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                                        .addComponent(recognitionLabel, GroupLayout.PREFERRED_SIZE, 44,
+                                                GroupLayout.PREFERRED_SIZE))
+                                .addComponent(panelCar, GroupLayout.DEFAULT_SIZE, GroupLayout.DEFAULT_SIZE,
+                                        Short.MAX_VALUE))
+                        .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(bottomLine)));
         pack();
     }
 


### PR DESCRIPTION
## Summary
- replace the obsolete org.jdesktop GroupLayout/LayoutStyle imports with the javax.swing equivalents
- adjust the FrameComponentInit, FrameHelp, and FrameMain layouts to use the modern GroupLayout API methods

## Testing
- `mvn -q -DskipTests package` *(fails: unable to resolve Spring Boot dependencies due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e3bd427c2c8332ae9c96fd8b7c80bb