### PR TITLE
Add bean validation dependency

### DIFF
--- a/uae-anpr/pom.xml
+++ b/uae-anpr/pom.xml
@@ -36,6 +36,10 @@
             <version>2.5.0</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.bytedeco</groupId>
             <artifactId>opencv-platform</artifactId>
             <version>4.9.0-1.5.10</version>


### PR DESCRIPTION
## Summary
- add the Spring Boot bean validation starter to the project dependencies so a provider is available at runtime

## Testing
- `mvn -q -DskipTests package` *(fails: cannot download dependencies in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c101b2f88332b4b8bedd5e7dc633