### PR TITLE
Add multipart upload endpoint and document recognition pipeline

### DIFF
--- a/uae-anpr/README.md
+++ b/uae-anpr/README.md
@@ -1,0 +1,62 @@
+# UAE Car Plate Recognition Service
+
+This project exposes a Spring Boot service that performs automatic number plate recognition (ANPR) for UAE style licence plates. The service combines deterministic computer vision operators implemented with OpenCV and a Tesseract OCR backend tailored to the typographic characteristics of local plates.
+
+## Recognition pipeline
+
+The recognition flow executed for both API endpoints is summarised below:
+
+1. **Load and normalise** – the raw image payload is decoded into an OpenCV `Mat`. Images narrower than 640px are upscaled with bicubic interpolation to preserve character detail before later filtering stages.【F:src/main/java/com/uae/anpr/service/preprocessing/ImagePreprocessor.java†L24-L42】
+2. **Contrast enhancement** – the image is converted to grayscale, processed with CLAHE to limit histogram over-amplification, smoothed with a bilateral filter and highlighted with a morphological top-hat operator to emphasise plate ridges.【F:src/main/java/com/uae/anpr/service/preprocessing/ImagePreprocessor.java†L44-L66】
+3. **Adaptive binarisation** – the enhanced raster is binarised via mean adaptive thresholding followed by morphological closure to consolidate the character foreground for contour analysis.【F:src/main/java/com/uae/anpr/service/preprocessing/ImagePreprocessor.java†L68-L81】
+4. **Candidate extraction** – contours are enumerated, filtered by aspect ratio and area heuristics, and candidate regions are cropped from the colour image for downstream OCR.【F:src/main/java/com/uae/anpr/service/preprocessing/ImagePreprocessor.java†L83-L110】
+5. **OCR decoding** – every candidate is evaluated using a Tess4J-powered Tesseract engine configured with a whitelist of alphanumeric characters, fixed DPI and numeric mode. Results are normalised and filtered by confidence before returning the best match.【F:src/main/java/com/uae/anpr/service/ocr/TesseractOcrEngine.java†L24-L78】【F:src/main/java/com/uae/anpr/service/pipeline/RecognitionPipeline.java†L34-L48】
+
+## Running locally
+
+1. Install Java 17 and Maven 3.9+.
+2. From the repository root run:
+
+   ```bash
+   mvn spring-boot:run
+   ```
+
+   The service starts on `http://localhost:8080`.
+
+## API usage
+
+Both endpoints respond with the same JSON payload:
+
+```json
+{
+  "plateNumber": "M12345",
+  "confidence": 0.97,
+  "accepted": true
+}
+```
+
+### Recognise from Base64 JSON
+
+```bash
+curl -X POST http://localhost:8080/api/v1/anpr/recognize \
+  -H "Content-Type: application/json" \
+  -d '{"imageBase64": "<base64-encoded-image>"}'
+```
+
+### Recognise from uploaded file
+
+```bash
+curl -X POST http://localhost:8080/api/v1/anpr/recognize/file \
+  -H "Content-Type: multipart/form-data" \
+  -F "image=@/path/to/plate.jpg"
+```
+
+The multipart variant streams the raw image bytes directly to the pipeline without requiring client-side Base64 encoding.【F:src/main/java/com/uae/anpr/api/OcrController.java†L39-L73】
+
+## Error handling
+
+Invalid images or decoding issues return HTTP 400 with an empty recognition payload. This covers malformed Base64 strings, empty uploads and unreadable files.【F:src/main/java/com/uae/anpr/api/OcrController.java†L39-L73】
+
+## License
+
+See the repository for licensing details.

--- a/uae-anpr/src/main/java/com/uae/anpr/api/OcrController.java
+++ b/uae-anpr/src/main/java/com/uae/anpr/api/OcrController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
 import java.util.Base64;
 import java.util.Optional;
 import org.springframework.http.MediaType;
@@ -19,7 +20,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping(path = "/api/v1/anpr", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -45,16 +48,40 @@ public class OcrController {
     public ResponseEntity<RecognitionResponse> recognize(@RequestBody RecognitionRequest request) {
         byte[] imageBytes = Base64.getDecoder().decode(request.imageBase64());
         Optional<OcrResult> result = pipeline.recognize(imageBytes);
-        if (result.isEmpty()) {
-            return ResponseEntity.ok(new RecognitionResponse(null, 0.0, false));
+        return ResponseEntity.ok(toResponse(result));
+    }
+
+    @PostMapping(value = "/recognize/file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "Recognize a UAE car plate number from an uploaded image",
+            description = "Accepts a multipart image file, performs enhancement and OCR",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Recognition result",
+                            content = @Content(schema = @Schema(implementation = RecognitionResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "Invalid payload")
+            })
+    public ResponseEntity<RecognitionResponse> recognizeFile(@RequestPart("image") MultipartFile image) {
+        if (image == null || image.isEmpty()) {
+            throw new IllegalArgumentException("Uploaded image must not be empty");
         }
-        OcrResult ocrResult = result.get();
-        boolean accepted = ocrResult.confidence() >= properties.ocr().confidenceThreshold();
-        return ResponseEntity.ok(new RecognitionResponse(ocrResult.text(), ocrResult.confidence(), accepted));
+        try {
+            Optional<OcrResult> result = pipeline.recognize(image.getBytes());
+            return ResponseEntity.ok(toResponse(result));
+        } catch (IOException ex) {
+            throw new IllegalStateException("Unable to read uploaded image", ex);
+        }
     }
 
     @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
     public ResponseEntity<RecognitionResponse> handleIllegalArgument(RuntimeException ex) {
         return ResponseEntity.badRequest().body(new RecognitionResponse(null, 0.0, false));
+    }
+
+    private RecognitionResponse toResponse(Optional<OcrResult> result) {
+        if (result.isEmpty()) {
+            return new RecognitionResponse(null, 0.0, false);
+        }
+        OcrResult ocrResult = result.get();
+        boolean accepted = ocrResult.confidence() >= properties.ocr().confidenceThreshold();
+        return new RecognitionResponse(ocrResult.text(), ocrResult.confidence(), accepted);
     }
 }


### PR DESCRIPTION
## Summary
- add a multipart/form-data endpoint that accepts raw image uploads for OCR
- reuse common response construction logic between API variants
- document the computer vision pipeline and usage instructions in a new README

## Testing
- mvn -q -DskipTests package *(fails: unable to download Spring Boot dependencies due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e495ff86888332bef89f30216aae5f