### PR TITLE
Normalize OCR output before filtering characters

### DIFF
--- a/uae-anpr/src/main/java/com/uae/anpr/service/ocr/TesseractOcrEngine.java
+++ b/uae-anpr/src/main/java/com/uae/anpr/service/ocr/TesseractOcrEngine.java
@@ -6,6 +6,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Locale;
 import java.util.Optional;
 import net.sourceforge.tess4j.ITesseract;
 import net.sourceforge.tess4j.Tesseract;
@@ -52,7 +53,10 @@ public class TesseractOcrEngine {
             if (text == null) {
                 return Optional.empty();
             }
-            String normalized = text.replaceAll("[^A-Z0-9]", "").trim();
+            String normalized = text
+                    .toUpperCase(Locale.ROOT)
+                    .replaceAll("[^A-Z0-9]", "")
+                    .trim();
             if (normalized.isEmpty()) {
                 return Optional.empty();
             }


### PR DESCRIPTION
## Summary
- normalise raw Tesseract text to uppercase before filtering invalid characters so lowercase hits are preserved
- import `Locale` to support deterministic case conversion

## Testing
- mvn -q -DskipTests compile *(fails: Maven cannot download Spring Boot dependencies in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e497c1ef848332b1474ba8a6630bec