### PR TITLE
Adjust logging configuration to reduce auto-configuration noise

### DIFF
--- a/uae-anpr/src/main/resources/logback.xml
+++ b/uae-anpr/src/main/resources/logback.xml
@@ -24,8 +24,9 @@
     </appender>
 
     <logger name="net.sf.javaanpr" level="TRACE"/>
+    <logger name="com.uae.anpr" level="DEBUG"/>
 
-    <root level="debug">
+    <root level="info">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
## Summary
- lower the root logback level to INFO to prevent Spring Boot's condition evaluation report from printing every startup
- add an explicit DEBUG logger for com.uae.anpr to retain detailed application diagnostics

## Testing
- mvn -q -DskipTests package *(fails: repository access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e497da275083328d88613499866ebc