### PR TITLE
Expose structured plate metadata in recognition responses

### DIFF
--- a/uae-anpr/README.md
+++ b/uae-anpr/README.md
@@ -29,7 +29,10 @@ Both endpoints respond with the same JSON payload:
 
 ```json
 {
-  "plateNumber": "M12345",
+  "plateNumber": "DUBAIA12345",
+  "city": "Dubai",
+  "plateCharacter": "A",
+  "carNumber": "12345",
   "confidence": 0.97,
   "accepted": true
 }

--- a/uae-anpr/src/main/java/com/uae/anpr/api/dto/RecognitionResponse.java
+++ b/uae-anpr/src/main/java/com/uae/anpr/api/dto/RecognitionResponse.java
@@ -5,6 +5,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record RecognitionResponse(
         @Schema(description = "Normalized alphanumeric UAE plate number")
         String plateNumber,
+        @Schema(description = "Detected emirate or city name if derivable from the plate text")
+        String city,
+        @Schema(description = "Alphabetic classification character(s) printed on the plate")
+        String plateCharacter,
+        @Schema(description = "Numeric component of the plate")
+        String carNumber,
         @Schema(description = "Confidence score emitted by OCR")
         double confidence,
         @Schema(description = "Whether the detection reached the configured acceptance threshold")

--- a/uae-anpr/src/main/java/com/uae/anpr/service/parser/UaePlateParser.java
+++ b/uae-anpr/src/main/java/com/uae/anpr/service/parser/UaePlateParser.java
@@ -1,0 +1,148 @@
+package com.uae.anpr.service.parser;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/**
+ * Utility component that derives structured UAE plate attributes from OCR text.
+ */
+@Component
+public class UaePlateParser {
+
+    private static final List<CityPattern> CITY_PATTERNS = List.of(
+            new CityPattern("ABUDHABI", "Abu Dhabi"),
+            new CityPattern("AUH", "Abu Dhabi"),
+            new CityPattern("ALAIN", "Al Ain"),
+            new CityPattern("DUBAI", "Dubai"),
+            new CityPattern("DXB", "Dubai"),
+            new CityPattern("SHARJAH", "Sharjah"),
+            new CityPattern("SHJ", "Sharjah"),
+            new CityPattern("AJMAN", "Ajman"),
+            new CityPattern("AJM", "Ajman"),
+            new CityPattern("UMMALQUWAIN", "Umm Al Quwain"),
+            new CityPattern("UAQ", "Umm Al Quwain"),
+            new CityPattern("RASALKHAIMAH", "Ras Al Khaimah"),
+            new CityPattern("RAK", "Ras Al Khaimah"),
+            new CityPattern("FUJAIRAH", "Fujairah"),
+            new CityPattern("FJR", "Fujairah")
+    );
+
+    /**
+     * Parse the OCR text into structured plate details.
+     *
+     * @param plateText normalized OCR output consisting of alphanumeric characters
+     * @return structured breakdown of the plate text
+     */
+    public PlateBreakdown parse(String plateText) {
+        if (plateText == null || plateText.isBlank()) {
+            return PlateBreakdown.empty();
+        }
+
+        String normalized = plateText.toUpperCase(Locale.ROOT).replaceAll("[^A-Z0-9]", "");
+        if (normalized.isEmpty()) {
+            return PlateBreakdown.empty();
+        }
+
+        String digits = normalized.chars()
+                .filter(Character::isDigit)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+
+        int firstDigitIndex = indexOfFirstDigit(normalized);
+        int lastDigitIndex = indexOfLastDigit(normalized);
+
+        String letterPrefix = firstDigitIndex >= 0
+                ? normalized.substring(0, firstDigitIndex)
+                : normalized;
+        letterPrefix = letterPrefix.replaceAll("[^A-Z]", "");
+
+        String letterSuffix = lastDigitIndex >= 0 && lastDigitIndex < normalized.length() - 1
+                ? normalized.substring(lastDigitIndex + 1)
+                : "";
+        letterSuffix = letterSuffix.replaceAll("[^A-Z]", "");
+
+        CityPattern cityMatch = resolveCity(letterPrefix, normalized);
+        if (cityMatch == null) {
+            cityMatch = resolveCity(letterSuffix, normalized);
+        }
+
+        String city = cityMatch != null ? cityMatch.city() : null;
+        String plateCharacter = deriveClassification(letterPrefix, letterSuffix, cityMatch);
+        String carNumber = digits.isEmpty() ? null : digits;
+
+        return new PlateBreakdown(city, plateCharacter, carNumber);
+    }
+
+    private String deriveClassification(String prefixLetters, String suffixLetters, CityPattern cityMatch) {
+        String candidate = normalizeClassification(prefixLetters, cityMatch);
+        if (candidate != null) {
+            return candidate;
+        }
+        candidate = normalizeClassification(suffixLetters, cityMatch);
+        return candidate;
+    }
+
+    private String normalizeClassification(String value, CityPattern cityMatch) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String stripped = value;
+        if (cityMatch != null && stripped.startsWith(cityMatch.code())) {
+            stripped = stripped.substring(cityMatch.code().length());
+        }
+        stripped = stripped.replaceAll("[^A-Z]", "");
+        if (stripped.isBlank()) {
+            return null;
+        }
+        return stripped;
+    }
+
+    private CityPattern resolveCity(String scopedLetters, String normalizedPlate) {
+        if (scopedLetters != null && !scopedLetters.isBlank()) {
+            Optional<CityPattern> scopedMatch = CITY_PATTERNS.stream()
+                    .filter(pattern -> scopedLetters.startsWith(pattern.code()))
+                    .max(Comparator.comparingInt(pattern -> pattern.code().length()));
+            if (scopedMatch.isPresent()) {
+                return scopedMatch.get();
+            }
+        }
+
+        return CITY_PATTERNS.stream()
+                .filter(pattern -> normalizedPlate.contains(pattern.code()))
+                .max(Comparator.comparingInt(pattern -> pattern.code().length()))
+                .orElse(null);
+    }
+
+    private int indexOfFirstDigit(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            if (Character.isDigit(value.charAt(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private int indexOfLastDigit(String value) {
+        for (int i = value.length() - 1; i >= 0; i--) {
+            if (Character.isDigit(value.charAt(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private record CityPattern(String code, String city) {
+    }
+
+    public record PlateBreakdown(String city, String plateCharacter, String carNumber) {
+
+        private static final PlateBreakdown EMPTY = new PlateBreakdown(null, null, null);
+
+        public static PlateBreakdown empty() {
+            return EMPTY;
+        }
+    }
+}

--- a/uae-anpr/src/test/java/com/uae/anpr/service/parser/UaePlateParserTest.java
+++ b/uae-anpr/src/test/java/com/uae/anpr/service/parser/UaePlateParserTest.java
@@ -1,0 +1,52 @@
+package com.uae.anpr.service.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.uae.anpr.service.parser.UaePlateParser.PlateBreakdown;
+import org.junit.jupiter.api.Test;
+
+class UaePlateParserTest {
+
+    private final UaePlateParser parser = new UaePlateParser();
+
+    @Test
+    void parsesDubaiPlateWithCityAndLetter() {
+        PlateBreakdown breakdown = parser.parse("DUBAIA12345");
+        assertEquals("Dubai", breakdown.city());
+        assertEquals("A", breakdown.plateCharacter());
+        assertEquals("12345", breakdown.carNumber());
+    }
+
+    @Test
+    void parsesAbuDhabiPlate() {
+        PlateBreakdown breakdown = parser.parse("ABUDHABIA54321");
+        assertEquals("Abu Dhabi", breakdown.city());
+        assertEquals("A", breakdown.plateCharacter());
+        assertEquals("54321", breakdown.carNumber());
+    }
+
+    @Test
+    void fallsBackToSingleLetterWhenCityUnknown() {
+        PlateBreakdown breakdown = parser.parse("M12345");
+        assertNull(breakdown.city());
+        assertEquals("M", breakdown.plateCharacter());
+        assertEquals("12345", breakdown.carNumber());
+    }
+
+    @Test
+    void supportsLetterAfterDigits() {
+        PlateBreakdown breakdown = parser.parse("1234A");
+        assertNull(breakdown.city());
+        assertEquals("A", breakdown.plateCharacter());
+        assertEquals("1234", breakdown.carNumber());
+    }
+
+    @Test
+    void returnsEmptyBreakdownForInvalidInput() {
+        PlateBreakdown breakdown = parser.parse("   ");
+        assertNull(breakdown.city());
+        assertNull(breakdown.plateCharacter());
+        assertNull(breakdown.carNumber());
+    }
+}


### PR DESCRIPTION
## Summary
- add a UAE-specific parser that derives the emirate, classification character, and numeric portion from OCR text
- extend the recognition response DTO and controller to surface city, plate character, and car number fields
- document the richer JSON payload and cover the parsing heuristics with unit tests

## Testing
- mvn test *(fails: repository access to Maven Central is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e497f4b2808332ba5446a206928556