### PR TITLE
Penalize digit-only OCR hypotheses

### DIFF
--- a/uae-anpr/src/main/java/com/uae/anpr/service/pipeline/ResultAggregator.java
+++ b/uae-anpr/src/main/java/com/uae/anpr/service/pipeline/ResultAggregator.java
@@ -140,6 +140,13 @@ public class ResultAggregator {
             if (!containsDigits()) {
                 penalty += 0.08;
             }
+            String classification = breakdown.plateCharacter();
+            if (classification == null || classification.isBlank()) {
+                penalty += 0.04;
+            }
+            if (!containsLetters()) {
+                penalty += 0.05;
+            }
             if (text.length() < 4) {
                 penalty += 0.04;
             }

--- a/uae-anpr/src/test/java/com/uae/anpr/service/pipeline/ResultAggregatorTest.java
+++ b/uae-anpr/src/test/java/com/uae/anpr/service/pipeline/ResultAggregatorTest.java
@@ -56,4 +56,19 @@ class ResultAggregatorTest {
         assertTrue(best.isPresent());
         assertTrue(best.get().confidence() > 0.85, "Consensus should lift the aggregated confidence");
     }
+
+    @Test
+    void penalisesDigitOnlyCandidatesWhenStructuredAlternativeExists() {
+        List<OcrResult> candidates = List.of(
+                new OcrResult("45158", 0.999),
+                new OcrResult("AUHA45158", 0.92),
+                new OcrResult("A45158", 0.93));
+
+        Optional<ResultAggregator.AggregatedResult> best = aggregator.selectBest(candidates, 0.85);
+
+        assertTrue(best.isPresent());
+        assertEquals("AUHA45158", best.get().text());
+        assertEquals("Abu Dhabi", best.get().breakdown().city());
+        assertEquals("A", best.get().breakdown().plateCharacter());
+    }
 }


### PR DESCRIPTION
## Summary
- add additional structure penalties so digit-only OCR candidates are less competitive than structured readings
- extend the result aggregator tests to cover enrichment with city and character metadata

## Testing
- mvn test *(fails: dependency resolution blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a6437a808332b6ce522fad2926fd