### PR TITLE
Disable numeric-only OCR mode when whitelist includes letters

### DIFF
--- a/uae-anpr/src/test/java/com/uae/anpr/service/ocr/TesseractOcrEngineTest.java
+++ b/uae-anpr/src/test/java/com/uae/anpr/service/ocr/TesseractOcrEngineTest.java
@@ -1,0 +1,31 @@
+package com.uae.anpr.service.ocr;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class TesseractOcrEngineTest {
+
+    @Nested
+    @DisplayName("shouldForceNumericMode")
+    class ShouldForceNumericMode {
+
+        @Test
+        void returnsFalseWhenWhitelistContainsLetters() {
+            assertFalse(TesseractOcrEngine.shouldForceNumericMode("0123ABZ"));
+        }
+
+        @Test
+        void returnsTrueForDigitsOnlyWhitelist() {
+            assertTrue(TesseractOcrEngine.shouldForceNumericMode("0123456789"));
+        }
+
+        @Test
+        void returnsFalseForEmptyWhitelist() {
+            assertFalse(TesseractOcrEngine.shouldForceNumericMode("   "));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- only force Tesseract's numeric mode when the whitelist is restricted to digits so that alphanumeric plates retain their letter glyphs
- add a focused unit test covering the numeric-mode decision helper

## Testing
- `mvn test` *(fails: unable to download org.springframework.boot:spring-boot-dependencies:3.3.2 from Maven Central – HTTP 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e4aa3017e883329009f8a692f53910