### PR TITLE
Bias aggregator toward alphanumeric plate hypotheses

### DIFF
--- a/uae-anpr/src/main/java/com/uae/anpr/service/pipeline/ResultAggregator.java
+++ b/uae-anpr/src/main/java/com/uae/anpr/service/pipeline/ResultAggregator.java
@@ -91,7 +91,7 @@ public class ResultAggregator {
                 return Optional.empty();
             }
             double aggregatedConfidence = clamp(computeAggregatedConfidence());
-            double score = aggregatedConfidence + consensusBonus();
+            double score = aggregatedConfidence + consensusBonus() + structurePreference();
             return Optional.of(new AggregatedResult(text, aggregatedConfidence, score, occurrences, breakdown));
         }
 
@@ -142,15 +142,34 @@ public class ResultAggregator {
             }
             String classification = breakdown.plateCharacter();
             if (classification == null || classification.isBlank()) {
-                penalty += 0.04;
+                penalty += 0.07;
             }
             if (!containsLetters()) {
-                penalty += 0.05;
+                penalty += 0.08;
             }
             if (text.length() < 4) {
                 penalty += 0.04;
             }
             return penalty;
+        }
+
+        private double structurePreference() {
+            double preference = 0.0;
+            String classification = breakdown.plateCharacter();
+            if (classification != null && !classification.isBlank()) {
+                preference += 0.05;
+                if (classification.length() <= 2) {
+                    preference += 0.01;
+                }
+            } else {
+                preference -= 0.04;
+            }
+            if (containsLetters()) {
+                preference += 0.01;
+            } else {
+                preference -= 0.03;
+            }
+            return preference;
         }
 
         private boolean containsDigits() {

--- a/uae-anpr/src/test/java/com/uae/anpr/service/ocr/TesseractOcrEngineTest.java
+++ b/uae-anpr/src/test/java/com/uae/anpr/service/ocr/TesseractOcrEngineTest.java
@@ -1,0 +1,31 @@
+package com.uae.anpr.service.ocr;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class TesseractOcrEngineTest {
+
+    @Nested
+    @DisplayName("shouldForceNumericMode")
+    class ShouldForceNumericMode {
+
+        @Test
+        void returnsFalseWhenWhitelistContainsLetters() {
+            assertFalse(TesseractOcrEngine.shouldForceNumericMode("0123ABZ"));
+        }
+
+        @Test
+        void returnsTrueForDigitsOnlyWhitelist() {
+            assertTrue(TesseractOcrEngine.shouldForceNumericMode("0123456789"));
+        }
+
+        @Test
+        void returnsFalseForEmptyWhitelist() {
+            assertFalse(TesseractOcrEngine.shouldForceNumericMode("   "));
+        }
+    }
+}

--- a/uae-anpr/src/test/java/com/uae/anpr/service/pipeline/ResultAggregatorTest.java
+++ b/uae-anpr/src/test/java/com/uae/anpr/service/pipeline/ResultAggregatorTest.java
@@ -71,4 +71,17 @@ class ResultAggregatorTest {
         assertEquals("Abu Dhabi", best.get().breakdown().city());
         assertEquals("A", best.get().breakdown().plateCharacter());
     }
+
+    @Test
+    void prefersLetteredCandidateEvenWhenDigitsHaveHigherConfidence() {
+        List<OcrResult> candidates = List.of(
+                new OcrResult("45158", 0.995),
+                new OcrResult("A45158", 0.88));
+
+        Optional<ResultAggregator.AggregatedResult> best = aggregator.selectBest(candidates, 0.80);
+
+        assertTrue(best.isPresent());
+        assertEquals("A45158", best.get().text());
+        assertEquals("A", best.get().breakdown().plateCharacter());
+    }
 }


### PR DESCRIPTION
## Summary
- increase penalties for digit-only OCR hypotheses and add a structure-aware score boost so candidates with classification letters rank higher
- extend the aggregator scoring with an explicit structure preference that rewards alphanumeric readings
- add a regression test asserting that a lower-confidence alphanumeric candidate is preferred over a higher-confidence digit-only result

## Testing
- `mvn test` *(fails: unable to resolve Spring Boot BOM from Maven Central – HTTP 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e4aa3017e883329009f8a692f53910