### PR TITLE
Fix Spring wiring for Tesseract OCR engine

### DIFF
--- a/uae-anpr/src/main/java/com/uae/anpr/service/ocr/TesseractOcrEngine.java
+++ b/uae-anpr/src/main/java/com/uae/anpr/service/ocr/TesseractOcrEngine.java
@@ -25,6 +25,7 @@ import org.bytedeco.opencv.global.opencv_imgcodecs;
 import org.bytedeco.opencv.opencv_core.Mat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,6 +35,7 @@ public class TesseractOcrEngine {
 
     private final ITesseract tesseract;
 
+    @Autowired
     public TesseractOcrEngine(AnprProperties properties) {
         this(create(properties));
     }

--- a/uae-anpr/src/test/java/com/uae/anpr/service/ocr/TesseractOcrEngineTest.java
+++ b/uae-anpr/src/test/java/com/uae/anpr/service/ocr/TesseractOcrEngineTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.List;
 import java.util.Optional;
@@ -22,10 +23,11 @@ class TesseractOcrEngineTest {
     @Test
     void usesWordConfidenceFromTesseract() throws Exception {
         ITesseract tess = Mockito.mock(ITesseract.class);
-        Mockito.when(tess.doOCR(ArgumentMatchers.any())).thenReturn("abc123");
+        Mockito.when(tess.doOCR(ArgumentMatchers.any(File.class))).thenReturn("abc123");
         Word word = Mockito.mock(Word.class);
-        Mockito.when(word.getConfidence()).thenReturn(73);
-        Mockito.when(tess.getWords(ArgumentMatchers.any(File.class), ArgumentMatchers.anyInt()))
+        Mockito.when(word.getConfidence()).thenReturn(73f);
+        Mockito.when(tess.getWords(
+                        ArgumentMatchers.any(BufferedImage.class), ArgumentMatchers.anyInt()))
                 .thenReturn(List.of(word));
 
         TesseractOcrEngine engine = new TesseractOcrEngine(tess);
@@ -41,8 +43,9 @@ class TesseractOcrEngineTest {
     @Test
     void returnsZeroConfidenceWhenWordConfidenceUnavailable() throws Exception {
         ITesseract tess = Mockito.mock(ITesseract.class);
-        Mockito.when(tess.doOCR(ArgumentMatchers.any())).thenReturn("DXB");
-        Mockito.when(tess.getWords(ArgumentMatchers.any(File.class), ArgumentMatchers.anyInt()))
+        Mockito.when(tess.doOCR(ArgumentMatchers.any(File.class))).thenReturn("DXB");
+        Mockito.when(tess.getWords(
+                        ArgumentMatchers.any(BufferedImage.class), ArgumentMatchers.anyInt()))
                 .thenThrow(new UnsupportedOperationException("no confidence"));
 
         TesseractOcrEngine engine = new TesseractOcrEngine(tess);


### PR DESCRIPTION
## Summary
- mark the Tesseract OCR engine's public constructor for dependency injection so Spring can supply AnprProperties
- import the @Autowired annotation required for the annotated constructor

## Testing
- mvn -q test *(fails: dependency resolution blocked by Maven Central 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e4be5642388332ba0048e8ae2767e8