### PR TITLE
Enforce recognition request validation and add MVC coverage

### DIFF
--- a/uae-anpr/src/main/java/com/uae/anpr/api/OcrController.java
+++ b/uae-anpr/src/main/java/com/uae/anpr/api/OcrController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import java.util.Base64;
 import java.util.Optional;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -49,8 +50,12 @@ public class OcrController {
                             content = @Content(schema = @Schema(implementation = RecognitionResponse.class))),
                     @ApiResponse(responseCode = "400", description = "Invalid payload")
             })
-    public ResponseEntity<RecognitionResponse> recognize(@RequestBody RecognitionRequest request) {
-        byte[] imageBytes = Base64.getDecoder().decode(request.imageBase64());
+    public ResponseEntity<RecognitionResponse> recognize(@Valid @RequestBody RecognitionRequest request) {
+        String base64Image = request.imageBase64();
+        if (base64Image == null || base64Image.isBlank()) {
+            throw new IllegalArgumentException("Image payload must not be blank");
+        }
+        byte[] imageBytes = Base64.getDecoder().decode(base64Image);
         Optional<OcrResult> result = pipeline.recognize(imageBytes);
         return ResponseEntity.ok(toResponse(result));
     }

--- a/uae-anpr/src/test/java/com/uae/anpr/api/OcrControllerMvcTest.java
+++ b/uae-anpr/src/test/java/com/uae/anpr/api/OcrControllerMvcTest.java
@@ -1,0 +1,61 @@
+package com.uae.anpr.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.uae.anpr.config.AnprProperties;
+import com.uae.anpr.config.AnprProperties.OcrProperties;
+import com.uae.anpr.config.AnprProperties.ResourceSet;
+import com.uae.anpr.service.pipeline.RecognitionPipeline;
+import com.uae.anpr.service.parser.UaePlateParser;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(OcrController.class)
+@Import(OcrControllerMvcTest.TestConfig.class)
+class OcrControllerMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RecognitionPipeline recognitionPipeline;
+
+    @MockBean
+    private UaePlateParser uaePlateParser;
+
+    @Test
+    void recognizeReturnsBadRequestWhenImageIsMissing() throws Exception {
+        mockMvc.perform(post("/api/v1/anpr/recognize")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void recognizeReturnsBadRequestWhenImageIsBlank() throws Exception {
+        mockMvc.perform(post("/api/v1/anpr/recognize")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"imageBase64\":\"   \"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @Bean
+        AnprProperties anprProperties() {
+            return new AnprProperties(
+                    new ResourceSet(null, null, null, null),
+                    new OcrProperties("eng", 0.85, false, null, null));
+        }
+
+    }
+}


### PR DESCRIPTION
## Summary
- validate the JSON recognition request using `@Valid` and add a defensive guard for blank payloads
- keep the existing exception handler behavior by raising `IllegalArgumentException` before decoding
- add MockMvc tests that assert missing or blank Base64 payloads now return HTTP 400

## Testing
- `mvn test` *(fails: unable to download Spring Boot dependencies due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d6557eb083329fcfa6a040359650