### PR TITLE
Use normalized OCR text as API plate number

### DIFF
--- a/uae-anpr/src/main/java/com/uae/anpr/api/OcrController.java
+++ b/uae-anpr/src/main/java/com/uae/anpr/api/OcrController.java
@@ -87,9 +87,12 @@ public class OcrController {
         OcrResult ocrResult = result.get();
         boolean accepted = ocrResult.confidence() >= properties.ocr().confidenceThreshold();
         PlateBreakdown breakdown = plateParser.parse(ocrResult.text());
-        String plateNumber = breakdown.carNumber();
+        String plateNumber = ocrResult.text();
+        if (plateNumber != null) {
+            plateNumber = plateNumber.strip();
+        }
         if (plateNumber == null || plateNumber.isBlank()) {
-            plateNumber = ocrResult.text();
+            plateNumber = breakdown.carNumber();
         }
         return new RecognitionResponse(
                 plateNumber,

--- a/uae-anpr/src/test/java/com/uae/anpr/api/OcrControllerTest.java
+++ b/uae-anpr/src/test/java/com/uae/anpr/api/OcrControllerTest.java
@@ -11,40 +11,60 @@ import com.uae.anpr.config.AnprProperties.OcrProperties;
 import com.uae.anpr.config.AnprProperties.ResourceSet;
 import com.uae.anpr.service.ocr.TesseractOcrEngine.OcrResult;
 import com.uae.anpr.service.parser.UaePlateParser;
+import com.uae.anpr.service.parser.UaePlateParser.PlateBreakdown;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class OcrControllerTest {
 
+    private AnprProperties properties;
     private OcrController controller;
 
     @BeforeEach
     void setUp() {
-        AnprProperties properties = new AnprProperties(
+        properties = new AnprProperties(
                 new ResourceSet(null, null, null, null),
                 new OcrProperties("eng", 0.85, false, null, null));
         controller = new OcrController(null, properties, new UaePlateParser());
     }
 
     @Test
-    void toResponsePrefersDigitsWhenAvailable() {
-        RecognitionResponse response = controller.toResponse(Optional.of(new OcrResult("45158X", 0.97)));
+    void toResponseUsesNormalizedPlateTextWhenAvailable() {
+        RecognitionResponse response = controller.toResponse(Optional.of(new OcrResult("DUBAIF97344", 0.97)));
 
-        assertEquals("45158", response.plateNumber());
-        assertEquals("X", response.plateCharacter());
+        assertEquals("DUBAIF97344", response.plateNumber());
+        assertEquals("Dubai", response.city());
+        assertEquals("F", response.plateCharacter());
+        assertEquals("97344", response.carNumber());
         assertEquals(0.97, response.confidence());
         assertTrue(response.accepted());
     }
 
     @Test
-    void toResponseFallsBackToRawTextWhenDigitsUnavailable() {
+    void toResponseReturnsRawTextWhenNoDigitsDetected() {
         RecognitionResponse response = controller.toResponse(Optional.of(new OcrResult("DXB", 0.91)));
 
         assertEquals("DXB", response.plateNumber());
         assertNull(response.plateCharacter());
+        assertNull(response.carNumber());
         assertEquals(0.91, response.confidence());
         assertTrue(response.accepted());
+    }
+
+    @Test
+    void toResponseFallsBackToDigitsWhenTextBlank() {
+        OcrController fallbackController = new OcrController(null, properties, new UaePlateParser() {
+            @Override
+            public PlateBreakdown parse(String plateText) {
+                return new PlateBreakdown(null, null, "97344");
+            }
+        });
+
+        RecognitionResponse response = fallbackController.toResponse(Optional.of(new OcrResult("   ", 0.91)));
+
+        assertEquals("97344", response.plateNumber());
+        assertEquals("97344", response.carNumber());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- ensure the OCR controller returns the normalized OCR text in the plateNumber field with digit fallback
- expand controller tests to verify combined alphanumeric plate numbers and digit-only fallback behaviour

## Testing
- mvn test *(fails: remote repository access to Spring Boot dependencies is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d65465748332b08049cfb13f861d